### PR TITLE
Fix/envoys bearer token

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,0 +1,56 @@
+# Enlighten login
+
+```
+$ curl -vvv -X POST https://enlighten.enphaseenergy.com/login/login.json? \
+            -F "user[email]=bart@cloutrix.com"                            \
+            -F 'user[password]=BKi********5%h'
+
+{ "message":"success",
+  "session_id":"5ae67aa246e6947c0a87bb22f17d75ad",
+  "manager_token":"eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjp7InNlc3Npb25faWQiOiI1YWU2N2FhMjQ2ZTY5NDdjMGE4N2JiMjJmMTdkNzVhZCIsImNvbXBhbnlfaWQiOm51bGwsImVtYWlsX2lkIjoiYmFydEBjbG91dHJpeC5jb20iLCJ1c2VyX2lkIjoyMzQ3ODI3LCJjbGllbnRfYXBwIjoiaXRrMyIsImZpcnN0X25hbWUiOiJCYXJ0IiwibGFzdF9uYW1lIjoiVmVyY2FtbWVuIiwibG9naW5fdXNlciI6bnVsbCwiaXNfZGlzdHJpYnV0b3IiOmZhbHNlfSwiZXhwIjoxNjg5NjE4NTY2LCJzdWIiOiJiYXJ0QGNsb3V0cml4LmNvbSJ9.4ASKGp8yzXWEREJ3GTUlsggwqzB7RuR7KSU1oc0ht5Y",
+  "is_consumer":true
+}
+
+// manager-token JWT:
+{
+  "data": {
+    "session_id": "5ae67aa246e6947c0a87bb22f17d75ad",
+    "company_id": null,
+    "email_id": "bart@cloutrix.com",
+    "user_id": 2347827,
+    "client_app": "itk3",
+    "first_name": "Bart",
+    "last_name": "Vercammen",
+    "login_user": null,
+    "is_distributor": false
+  },
+  "exp": 1689618566,
+  "sub": "bart@cloutrix.com"
+}
+```
+```
+$ curl -X POST https://entrez.enphaseenergy.com/tokens  \
+       -H "Content-Type: application/json"              \
+       -d "{\"session_id\": \"$session_id\", \"serial_num\": \"$envoy_serial\", \"username\": \"$user\"}"
+
+{ "generation_time":1688975561,
+  "token":"eyJraWQiOiI3ZDEwMDA1ZC03ODk5LTRkMGQtYmNiNC0yNDRmOThlZTE1NmIiLCJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJhdWQiOiIxMjIwMzgwMTUyNzMiLCJpc3MiOiJFbnRyZXoiLCJlbnBoYXNlVXNlciI6Im93bmVyIiwiZXhwIjoxNzIwNTExNTYxLCJpYXQiOjE2ODg5NzU1NjEsImp0aSI6IjJkYmNkY2NiLWNkZWQtNGFjYi1iYjExLTQzYjg0ZjkzNjE1NCIsInVzZXJuYW1lIjoiYmFydEBjbG91dHJpeC5jb20ifQ.X6E-MKly5o0ugVsHKzlfUqk4BVVX9IXQ7VZSzV_hDrDyupl0EN3-rLXb7JT68bpUlDmrQTXMHSg1evGn1_Hn0A",
+  "expires_at":1720511561
+}
+
+// JWT token:
+{
+  "kid": "7d10005d-7899-4d0d-bcb4-244f98ee156b",
+  "typ": "JWT",
+  "alg": "ES256"
+}
+{
+  "aud": "122038015273",
+  "iss": "Entrez",
+  "enphaseUser": "owner",
+  "exp": 1720511561,
+  "iat": 1688975561,
+  "jti": "2dbcdccb-cded-4acb-bb11-43b84f936154",
+  "username": "bart@cloutrix.com"
+}
+```

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -7,9 +7,9 @@
         </encoder>
     </appender>
 
-    <logger name="cloutrix" level="info" />
+    <logger name="cloutrix" level="debug" />
 
-    <root level="warn">
+    <root level="info">
         <appender-ref ref="console"/>
     </root>
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
         </encoder>
     </appender>
 
-    <logger name="cloutrix" level="debug" />
+<!--    <logger name="cloutrix" level="debug" />-->
 
     <root level="info">
         <appender-ref ref="console"/>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -16,8 +16,9 @@ plugins { }
 envoy {
   class = cloutrix.energy.envoy.EnvoyDataProvider
   config.host = localhost
-  config.port = 443
-  config.auth-token = ${?ENLIGHTEN_AUTH_TOKEN}
+  config.port = 80
+  config.username = ${ENLIGHTEN_USERNAME}
+  config.password = ${ENLIGHTEN_PASSWORD}
 }
 
 saj {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -16,7 +16,8 @@ plugins { }
 envoy {
   class = cloutrix.energy.envoy.EnvoyDataProvider
   config.host = localhost
-  config.port = 80
+  config.port = 443
+  config.auth-token = ${?ENLIGHTEN_AUTH_TOKEN}
 }
 
 saj {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -17,8 +17,14 @@ envoy {
   class = cloutrix.energy.envoy.EnvoyDataProvider
   config.host = localhost
   config.port = 80
-  config.username = ${ENLIGHTEN_USERNAME}
-  config.password = ${ENLIGHTEN_PASSWORD}
+  config.tls  = false
+  config.login.url = "https://enlighten.enphaseenergy.com/login/login.json"
+  config.login.url = ${?ENLIGHTEN_LOGIN_URL}
+  config.token.url = "https://entrez.enphaseenergy.com/tokens"
+  config.token.url = ${?ENLIGHTEN_TOKEN_URL}
+  config.serial    = ${?ENLIGHTEN_SERIAL}
+  config.username  = ${?ENLIGHTEN_USERNAME}
+  config.password  = ${?ENLIGHTEN_PASSWORD}
 }
 
 saj {

--- a/src/main/scala/cloutrix/energy/envoy/EnvoyDataProvider.scala
+++ b/src/main/scala/cloutrix/energy/envoy/EnvoyDataProvider.scala
@@ -1,25 +1,112 @@
 package cloutrix.energy.envoy
 
-import cloutrix.energy.internal.{DataProviderCache, HttpConfig, HttpDataPoller}
+import cloutrix.energy.internal.{DataProviderCache, HttpClient, HttpConfig, HttpDataPoller}
+import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
 import com.typesafe.config.Config
-import com.typesafe.scalalogging.LazyLogging
+import com.typesafe.scalalogging.{LazyLogging, StrictLogging}
+import scalaj.http.{Http, HttpOptions, HttpRequest, HttpResponse, HttpStatusException}
 
-import scala.util.Try
+import java.net.{URL, URLEncoder}
+import java.nio.charset.StandardCharsets
+import scala.util.{Failure, Success, Try}
 
-class EnvoyDataProvider(config: Config, tokenProvider: () => String) extends HttpDataPoller with DataProviderCache with LazyLogging {
+case class Session(session_id: String, manager_token : String)
+object Session {
+  private val JsonCodec = JsonCodecMaker.make[Session]
+  val read: String => Session = readFromString(_: String)(JsonCodec)
+}
+
+case class Token(generation_time: Long, token: String, expires_at: Long)
+object Token {
+  private val JsonCodec = JsonCodecMaker.make[Token]
+  val read: String => Token = readFromString(_: String)(JsonCodec)
+}
+
+object EnvoyDataProvider extends StrictLogging {
+  def defaultTokenProvider(config: Config): Option[String] = {
+    Try(config.getString("username") -> config.getString("password")) match {
+      case Success(username -> password) =>
+        val tokenMaybe = onManagementSession(username, password)(config)
+          .flatMap(fetchJwt(_, config.getString("serial"), username)(config))
+
+        tokenMaybe match {
+          case Success(token) =>
+            logger.info("JWT token successfully refreshed")
+            Some(token)
+
+          case Failure(cause) =>
+            logger.error(s"error refreshing JWT token - cause: ${cause.toString}")
+            None
+        }
+
+      // URLs not configured -> no need to fetch tokens
+      case _ => None
+    }
+  }
+
+  private def fetchJwt(sessionId: String, serial: String, username: String)(config: Config): Try[String] = {
+    def req = Http(config.getString("token.url"))
+                .timeout(30000, 30000)
+                .header("Content-Type", "application/json")
+                .postData( s"""| {
+                               |   "session_id": "${sessionId}",
+                               |   "serial_num": "${serial}",
+                               |   "username": "${username}"
+                               | }
+                               """.stripMargin )
+
+    logger.warn(s"request new JWT token - sessionId: $sessionId, serial: $serial, username: $username")
+    req.asString match {
+      //FIXME: althoug Content-Type is set to 'application/json', the API returns plain text
+      //case resp if resp.is2xx => Try(Token.read(resp.body).token)
+      case resp if resp.is2xx => Success(resp.body)
+
+      case resp =>
+        Failure(HttpStatusException(resp.code, resp.header("Status").getOrElse("UNKNOWN"), resp.body.toString))
+    }
+  }
+
+  private def onManagementSession(username: String, password: String)(config: Config): Try[String] = {
+    def req = Http(config.getString("login.url"))
+      .timeout(30000, 30000)
+      .postForm(params = Seq(
+          "user[email]" -> username,
+          "user[password]" -> password
+      ))
+
+    logger.warn(s"request new Management session - username: $username")
+    req.asString match {
+      case resp if resp.is2xx => Try(Session.read(resp.body).session_id)
+      case resp =>
+        Failure(HttpStatusException(resp.code, resp.header("Status").getOrElse("UNKNOWN"), resp.body.toString))
+    }
+  }
+}
+
+class EnvoyDataProvider(config: Config, tokenProvider: Config => Option[String]) extends HttpDataPoller with DataProviderCache with LazyLogging {
+  def this(config: Config) = this(config, EnvoyDataProvider.defaultTokenProvider)
   implicit val httpConfig: HttpConfig = HttpConfig(
     host = config.getString("host"),
     port = config.getInt("port"),
-    tls = true
+    tls  = Try(config.getBoolean("tls")).getOrElse(false)
   )
 
   register("readings" -> ( "/ivp/meters/readings" , EnvoyMeterReading.read ), autoStart = false )
   register("metadata" -> ( "/ivp/meters"          , EnvoyMeterMetadata.read), autoStart = true  )
 
+  private var apiToken: Option[String] = tokenProvider(config)
+
   // will only be called upon reception of a 401
-  override def onAuthenticationHeaders(): Seq[(String, String)] = Seq(
-    "Authorization" -> "Bearer %s".format(tokenProvider())
-  )
+  override def on401(): Unit = {
+    logger.warn("401 received - refresh api-token")
+    apiToken = tokenProvider(config)
+  }
+
+  override def addCustomHeaders(req: HttpRequest): HttpRequest =
+                  apiToken
+                    .map(token => req.header("Authorization", "Bearer %s".format(token)))
+                    .getOrElse( req )
 
   private val metadataHandler: PartialFunction[(String, Any), Long] = {
     case (_, d: EnvoyMeterMetas) if d.all.exists(_.measurementType == "production") =>
@@ -49,7 +136,7 @@ class EnvoyDataProvider(config: Config, tokenProvider: () => String) extends Htt
 
   private var dataHandler: PartialFunction[(String, Any), Unit] = metadataHandler andThen { eid => dataHandler = readingsHandler(eid) }
 
-  override def onData(id: String, data: Any): Unit = (dataHandler orElse logAndIgnore)(id, data)
+  override def onData(id: String, dataMaybe: Option[Any]): Unit = dataMaybe.foreach((dataHandler orElse logAndIgnore)(id, _))
 
   override def onError(cause: Throwable): Unit =
     logger.warn(s"error processing HTTP request, ignore and retry - cause: ${cause.toString}")

--- a/src/main/scala/cloutrix/energy/envoy/EnvoyDataProvider.scala
+++ b/src/main/scala/cloutrix/energy/envoy/EnvoyDataProvider.scala
@@ -4,8 +4,15 @@ import cloutrix.energy.internal.{DataProviderCache, HttpConfig, HttpDataPoller}
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
 
+import scala.util.Try
+
 class EnvoyDataProvider(config: Config) extends HttpDataPoller with DataProviderCache with LazyLogging {
-  implicit val httpConfig: HttpConfig = HttpConfig(host = config.getString("host"), port = config.getInt("port"))
+  implicit val httpConfig: HttpConfig = HttpConfig(
+    host = config.getString("host"),
+    port = config.getInt("port"),
+    tls = true,
+    authToken = Try(config.getString("auth-token")).toOption
+  )
 
   register("readings" -> ( "/ivp/meters/readings" , EnvoyMeterReading.read ), autoStart = false )
   register("metadata" -> ( "/ivp/meters"          , EnvoyMeterMetadata.read), autoStart = true  )

--- a/src/main/scala/cloutrix/energy/internal/HttpClient.scala
+++ b/src/main/scala/cloutrix/energy/internal/HttpClient.scala
@@ -14,8 +14,7 @@ case class HttpConfig(
                        port: Int,
                        connectionTimeout: Duration = HttpClient.DefaultConnectionTimeout,
                        readTimeout: Duration = HttpClient.DefaultReadTimeout,
-                       tls: Boolean = false,
-                       authToken: Option[String] = None
+                       tls: Boolean = false
                      )
 
 object HttpClient {
@@ -24,6 +23,8 @@ object HttpClient {
 }
 
 trait HttpClient extends LazyLogging {
+  private var authHeaders: Seq[(String, String)] = onAuthenticationHeaders()
+
   protected def doHttpRequest[T](path: String, reader: String => T)(implicit config: HttpConfig): T = {
     def urlFor(path: String) = Some(new URL(if (config.tls) "https" else "http", config.host, config.port, path))
       .tapEach(url => logger.debug(s"HTTP URL: ${url.toString}"))
@@ -47,4 +48,6 @@ trait HttpClient extends LazyLogging {
 
     reader(reqFor(urlFor(path)).asString.body)
   }
+
+  protected def onAuthenticationHeaders(): Seq[(String, String)]
 }

--- a/src/main/scala/cloutrix/energy/internal/HttpClient.scala
+++ b/src/main/scala/cloutrix/energy/internal/HttpClient.scala
@@ -1,15 +1,21 @@
 package cloutrix.energy.internal
 
-import scalaj.http.Http
+import com.typesafe.scalalogging.LazyLogging
+import scalaj.http.{Http, HttpOptions}
 
 import java.net.URL
+import scala.Option.option2Iterable
+import scala.collection.IterableOnce.iterableOnceExtensionMethods
 import scala.concurrent.duration.{Duration, DurationInt}
+import scala.util.chaining.scalaUtilChainingOps
 
 case class HttpConfig(
                        host: String,
                        port: Int,
                        connectionTimeout: Duration = HttpClient.DefaultConnectionTimeout,
-                       readTimeout: Duration = HttpClient.DefaultReadTimeout
+                       readTimeout: Duration = HttpClient.DefaultReadTimeout,
+                       tls: Boolean = false,
+                       authToken: Option[String] = None
                      )
 
 object HttpClient {
@@ -17,10 +23,27 @@ object HttpClient {
   final val DefaultReadTimeout: Duration = 5.seconds
 }
 
-trait HttpClient {
+trait HttpClient extends LazyLogging {
   protected def doHttpRequest[T](path: String, reader: String => T)(implicit config: HttpConfig): T = {
-    def urlFor(path: String) = new URL("http", config.host, config.port, path)
-    def reqFor(url: URL) = Http(url.toString).timeout(config.connectionTimeout.toMillis.toInt, config.readTimeout.toMillis.toInt)
+    def urlFor(path: String) = Some(new URL(if (config.tls) "https" else "http", config.host, config.port, path))
+      .tapEach(url => logger.debug(s"HTTP URL: ${url.toString}"))
+      .head
+
+    def reqFor(url: URL) = {
+      def plainRequest = Http(url.toString)
+        .timeout(config.connectionTimeout.toMillis.toInt, config.readTimeout.toMillis.toInt)
+        .options(HttpOptions.allowUnsafeSSL)
+
+      val req = config.authToken
+        .map("Bearer %s".format(_))
+        .map(plainRequest.header("Authorization", _))
+        .getOrElse(
+          plainRequest
+        )
+
+      logger.debug(s"HTTP REQUEST: ${req.toString}")
+      req
+    }
 
     reader(reqFor(urlFor(path)).asString.body)
   }

--- a/src/main/scala/cloutrix/energy/internal/HttpDataPoller.scala
+++ b/src/main/scala/cloutrix/energy/internal/HttpDataPoller.scala
@@ -74,5 +74,5 @@ abstract class HttpDataPoller extends ScheduledDataPoller with HttpClient with L
 
   protected def onError(cause: Throwable): Unit = logger.error(s"Unhandled error: ${cause.toString}", cause)
 
-  protected def onData(id: String, data: Any): Unit
+  protected def onData(id: String, data: Option[Any]): Unit
 }

--- a/src/main/scala/cloutrix/energy/internal/Plugin.scala
+++ b/src/main/scala/cloutrix/energy/internal/Plugin.scala
@@ -8,7 +8,7 @@ case class PluginDesc(name: String, config: Config, ctor: Config => DataProvider
 object Plugin extends StrictLogging {
   def loadClass(clazz: String): Config => DataProvider = {
     val ctor = Class.forName(clazz).getDeclaredConstructor(classOf[Config])
-    logger.debug(s"loaded plugin - class: ${ctor.getName}")
+    logger.info(s"loaded plugin - class: ${ctor.getName}")
 
     config => ctor
                .newInstance(config)

--- a/src/main/scala/cloutrix/energy/saj/SajDataProvider.scala
+++ b/src/main/scala/cloutrix/energy/saj/SajDataProvider.scala
@@ -23,16 +23,18 @@ class SajDataProvider(config: Config) extends HttpDataPoller with DataProviderCa
     }
   }
 
-  override def onData(id: String, data: Any): Unit = {
-    data match {
-      case dd: SajMeterReading =>
+  override def onData(id: String, dataMaybe: Option[Any]): Unit = {
+    dataMaybe match {
+      case Some(dd: SajMeterReading) =>
         logger.info(s"current production data: ${dd}")
         // p-ac    is expressed in 'W', so OK for what Dobiss-NXT expects
         // e-total is expressed in 'kWh', so we need to convert it to 'Wh' what Dobiss-NXT expects
         cache(currentProduction = Some(dd.pAc.toInt), totalProduction = Some((dd.eTotal * 1000.0).toInt))
 
+      case Some(wtf) =>
+        logger.error(s"unhandled data delivery - id: ${id}, data: ${wtf}")
+
       case _ =>
-        logger.error(s"unhandled data delivery - id: ${id}, data: ${data}")
     }
   }
 }

--- a/src/test/scala/envoy/DataProviderWithAuthTests.scala
+++ b/src/test/scala/envoy/DataProviderWithAuthTests.scala
@@ -1,0 +1,111 @@
+package envoy
+
+import cloutrix.energy.envoy.EnvoyDataProvider
+import cloutrix.energy.internal.AccumulatingDataProvider
+import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+import org.scalatest.concurrent.Eventually
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Seconds, Span}
+import org.scalatest.wordspec.AnyWordSpec
+import testutils.MockHttpServer
+
+import java.util.concurrent.{Executors, ScheduledExecutorService}
+import scala.concurrent.duration.DurationInt
+
+class DataProviderWithAuthTests extends AnyWordSpec with Matchers with BeforeAndAfterAll with BeforeAndAfter with Eventually {
+  private val mockHttp = new MockHttpServer
+
+  private val config = ConfigFactory.empty()
+    .withValue("host", ConfigValueFactory.fromAnyRef("localhost"))
+    .withValue("port", ConfigValueFactory.fromAnyRef(Int.box(mockHttp.port)))
+    .withValue("login.url" , ConfigValueFactory.fromAnyRef(s"http://localhost:${mockHttp.port}/login"))
+    .withValue("token.url" , ConfigValueFactory.fromAnyRef(s"http://localhost:${mockHttp.port}/token"))
+    .withValue("username", ConfigValueFactory.fromAnyRef("dummy"))
+    .withValue("password", ConfigValueFactory.fromAnyRef("password.1"))
+    .withValue("serial", ConfigValueFactory.fromAnyRef("serial-number"))
+
+  private implicit val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
+
+  private var loginDone: Boolean = false
+  private var tokenDone: Boolean = false
+
+  override def beforeAll(): Unit = {
+    mockHttp.start()
+    mockHttp.register("/login") { loginDone = true ; """{"session_id": "deadbeaf","manager_token":"xxxxxxxxxx"}""" }
+    mockHttp.register("/token") { tokenDone = true ; "xxxxxxxxxx-xxx-xxx-xxxxxxxxxx" }
+  }
+
+  override def afterAll(): Unit = mockHttp.stop()
+
+  before {
+    loginDone = false
+    tokenDone = false
+  }
+
+  after { }
+
+  "data can be scraped from EnvoyS on interval" when {
+    "an intermediate 401 is returned" in {
+      mockHttp.register("/ivp/meters")(Envoy.sampleMeter)
+      mockHttp.register("/ivp/meters/readings")(Envoy.sampleMeterReadings(activePower = 666.0, actEnergyDlvd = 777.0))
+
+      val provider = new EnvoyDataProvider(config)
+      provider.start(1.second)
+
+      eventually(timeout(Span(10, Seconds))) {
+        loginDone should be(true)
+        tokenDone should be(true)
+        provider.currentProduction should be(666)
+        provider.totalProduction should be(777)
+      }
+
+      loginDone = false
+      tokenDone = false
+      mockHttp.force401()
+
+      eventually(timeout(Span(10, Seconds))) {
+        loginDone should be(true)
+        tokenDone should be(true)
+        provider.currentProduction should be(666)
+        provider.totalProduction should be(777)
+      }
+    }
+
+    "only a single one is configured" in {
+      mockHttp.register("/ivp/meters")(Envoy.sampleMeter)
+      mockHttp.register("/ivp/meters/readings")(Envoy.sampleMeterReadings(activePower = 666.0, actEnergyDlvd = 777.0))
+
+      val provider = new EnvoyDataProvider(config)
+      provider.start(1.second)
+
+      eventually(timeout(Span(10, Seconds))) {
+        loginDone should be(true)
+        tokenDone should be(true)
+        provider.currentProduction should be(666)
+        provider.totalProduction should be(777)
+      }
+
+      provider.stop()
+    }
+  }
+
+  "multiple ones are aggregated through an AccumulatingDataProvider" in {
+    mockHttp.register("/ivp/meters")(Envoy.sampleMeter)
+    mockHttp.register("/ivp/meters/readings")(Envoy.sampleMeterReadings(activePower = 111.0, actEnergyDlvd = 222.0))
+
+    val COUNT = 3
+    val providers = (0 until COUNT).map(_ => new EnvoyDataProvider(config))
+    val provider = new AccumulatingDataProvider(providers)
+    providers.foreach(_.start(1.second))
+
+    eventually(timeout(Span(10, Seconds))) {
+      loginDone should be(true)
+      tokenDone should be(true)
+      provider.currentProduction should be(111 * COUNT)
+      provider.totalProduction should be(222 * COUNT)
+    }
+
+    providers.foreach(_.stop())
+  }
+}


### PR DESCRIPTION
EnvoyS recently switched to https with Bearer token.
In order for the local http requests to work, we now need a token which we need to fetch with Enlighten.