### PR TITLE
fix(envoy): enphase login broken

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,18 +13,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 21
-      uses: actions/setup-java@v3
-      with:
-        java-version: '21'
-        distribution: 'temurin'
-        cache: 'sbt'
-    - name: Clean workspace
-      run: sbt clean update
-    - name: Build project
-      run: sbt compile
-    - name: Build tests
-      run: sbt test:compile
-    - name: Run tests
-      run: sbt test
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: sbt
+      - name: Setup sbt launcher
+        uses: sbt/setup-sbt@v1
+      - name: Clean workspace
+        run: sbt clean update
+      - name: Build project
+        run: sbt compile
+      - name: Build tests
+        run: sbt Test/compile
+      - name: Run tests
+        run: sbt test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: 'sbt'
     - name: Clean workspace

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ target/
 
 # WEB
 web/
+
+# LOCAL SCRIPTS
+scripts/

--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ The table below gives an overview of the Modbus registers that are being read by
 The idea is thus to map the registers depicted above to the correct stats coming from EnvoyS.
 EnvoyS has a bunch of APIs to query stuff, but the one that gives us the most useful data is `/ivp/meters/readings`.
 
+Get Login Token:
+```
+The access token can be generated via shell commands or python commands through CLI as given below:
+
+Shell command:
+user='<UserName>'
+password='<Password>'
+envoy_serial='<Envoy_SerilaNo>'
+
+session_id=$(curl -X POST https://enlighten.enphaseenergy.com/login/login.json? -F "user[email]=$user" -F "user[password]=$password" | jq -r ".session_id")
+web_token=$(curl -X POST https://entrez.enphaseenergy.com/tokens -H "Content-Type: application/json" -d "{\"session_id\": \"$session_id\", \"serial_num\": \"$envoy_serial\", \"username\": \"$user\"}")
+
+The variable web_token is the access token.
+```
+
 ### /ivp/meters
 
 The `/ivp/meters` endpoint can be used to get the `eid` for the production statistics queried through `/ivp/meters/readings`.
@@ -106,7 +121,7 @@ to support other brands, as long as they have an HTTP API that can be used to qu
     // > cache(currentProduction = ..., totalProduction = ...)
   }
   ```
-- configure your DataProvider (in [application.conf](src/test/resources/application.conf))
+- configure your DataProvider (in [application.conf](src/test/resources/test-app.conf))
   ```
   plugins {
     MyInverter = ${mine}

--- a/build.sbt
+++ b/build.sbt
@@ -2,81 +2,84 @@ import sbt.*
 import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations.*
 
 ThisBuild / name             := "dobiss-modbus-tcp"
-ThisBuild / scalaVersion     := "2.13.15"
+ThisBuild / scalaVersion     := "2.13.16"
 ThisBuild / organization     := "com.cloutrix"
 ThisBuild / organizationName := "clouTrix"
 ThisBuild / mainClass        := Some("cloutrix.energy.DobissModbusTcpProxy")
 
 lazy val JavaOpts = Seq(
-  "-Xmx64m",
-  "-Xms20m"
+    "-Xmx100m",
+    "-Xms64m"
 )
 
+lazy val save  = taskKey[Unit]("save docker container as zipped file")
+lazy val check = taskKey[Unit]("check if the remote container does not exist yet")
+
 lazy val dockerSettings = Seq(
-  Docker/ packageName     := "cloutrix/dobiss-modbus-tcp",
-  Docker / daemonUser     := "dobiss",
-  Docker / daemonGroup    := "dobiss",
-  Docker / daemonUserUid  := Some("1666"),
-  Docker / daemonGroupGid := Some("1666"),
-  dockerBaseImage         := "azul/zulu-openjdk-alpine:17-jre-headless",
-  dockerExposedPorts      := Seq(1502),
-  Universal / javaOptions := JavaOpts.map("-J" + _)
+    Docker/ packageName     := "cloutrix/dobiss-modbus-tcp",
+    Docker / daemonUser     := "dobiss",
+    Docker / daemonGroup    := "dobiss",
+    Docker / daemonUserUid  := Some("1666"),
+    Docker / daemonGroupGid := Some("1666"),
+    dockerBaseImage         := "azul/zulu-openjdk-alpine:21-jre-headless",
+    dockerExposedPorts      := Seq(1502),
+    Universal / javaOptions := JavaOpts.map("-J" + _)
 )
 
 lazy val releaseBuildSettings = Seq(
-  releaseVersionBump := sbtrelease.Version.Bump.Bugfix,
-  releaseVersionFile := baseDirectory.value / "version.sbt",
+    releaseVersionBump := sbtrelease.Version.Bump.Bugfix,
+    releaseVersionFile := baseDirectory.value / "version.sbt",
 
-  publishConfiguration := publishConfiguration.value.withOverwrite(true),
-  releaseIgnoreUntrackedFiles := true,
+    publishConfiguration := publishConfiguration.value.withOverwrite(true),
+    releaseIgnoreUntrackedFiles := true,
 
-  releaseProcess := Seq[ReleaseStep](
-    checkSnapshotDependencies,
-    inquireVersions,
-    runClean,
-    runTest,
-    setReleaseVersion,
-    commitReleaseVersion,
-    tagRelease,
-    releaseStepTask(Docker / publish),
-    setNextVersion,
-    commitNextVersion,
-    pushChanges
-  )
+    releaseProcess := Seq[ReleaseStep](
+        checkSnapshotDependencies,
+        inquireVersions,
+        runClean,
+        runTest,
+        setReleaseVersion,
+        commitReleaseVersion,
+        tagRelease,
+        releaseStepTask(Docker / publish),
+        setNextVersion,
+        commitNextVersion,
+        pushChanges
+    )
 )
 
 lazy val coreDependencies = Seq(
-  libraryDependencies ++= Deps.All.Logging,
-  libraryDependencies ++= Deps.All.Jsoniter,
-  libraryDependencies ++= Deps.All.Netty,
-  libraryDependencies ++= Seq(
-    Deps.ScalaHttp,
-    Deps.Config,
-    Deps.Xml
-  )
+    libraryDependencies ++= Deps.All.Logging,
+    libraryDependencies ++= Deps.All.Jsoniter,
+    libraryDependencies ++= Deps.All.Netty,
+    libraryDependencies ++= Deps.All.Http,
+    libraryDependencies ++= Seq(
+        Deps.Config,
+        Deps.Xml
+    )
 )
 
 lazy val testSettings = Seq(
-  Test / fork               := true,
-  Test / parallelExecution  := false,
-  libraryDependencies       += TestDeps.ScalaTest,
-  Test / javaOptions        := JavaOpts
+    Test / fork               := true,
+    Test / parallelExecution  := false,
+    libraryDependencies       += TestDeps.ScalaTest,
+    Test / javaOptions        := JavaOpts
 )
 
 lazy val assemblySettings = Seq(
-  assembly / assemblyMergeStrategy := {
-    //workaround for conflict with netty manifest files
-    case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.first
-    case x                                                    => (assembly / assemblyMergeStrategy).value(x)
-  }
+    assembly / assemblyMergeStrategy := {
+        //workaround for conflict with netty manifest files
+        case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.first
+        case x                                                    => (assembly / assemblyMergeStrategy).value(x)
+    }
 )
 
 lazy val DobissModbusProxy = (project in file("."))
-  .enablePlugins(DockerPlugin, JavaServerAppPackaging, AshScriptPlugin)
-  .settings(
-    coreDependencies,
-    assemblySettings,
-    dockerSettings,
-    releaseBuildSettings,
-    testSettings
-  )
+    .enablePlugins(DockerPlugin, JavaServerAppPackaging, AshScriptPlugin)
+    .settings(
+        coreDependencies,
+        assemblySettings,
+        dockerSettings,
+        releaseBuildSettings,
+        testSettings
+    )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,38 +1,43 @@
 import sbt.*
 
 object Version {
-  final val Jsoniter = "2.31.1"
-  final val Logback = "1.5.12"
-  final val Logging = "3.9.5"
-  final val Config = "1.4.3"
-  final val ScalaHttp = "2.4.2"
-  final val Netty = "4.1.114.Final"
-  final val Xml = "2.3.0"
+    final val Jsoniter = "2.31.1"
+    final val Logback = "1.2.13"
+    final val Logging = "3.9.5"
+    final val Config = "1.4.3"
+    final val ScalaSttp = "4.0.11"
+    final val Netty = "4.2.6.Final"
+    final val Xml = "2.3.0"
+    final val NimbusJoseJwt = "10.5"
 
-  final val ScalaTest = "3.2.19"
+    final val ScalaTest = "3.2.19"
 }
 
 object Deps {
-  final val Jsoniter: ModuleID = "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % Version.Jsoniter excludeAll ExclusionRule("org.scala-lang")
-  final val JsoniterMacros: ModuleID = "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % Version.Jsoniter % "provided"
+    final val Jsoniter: ModuleID = "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % Version.Jsoniter excludeAll ExclusionRule("org.scala-lang")
+    final val JsoniterMacros: ModuleID = "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % Version.Jsoniter % "provided"
+    final val NimbusJoseJwt: ModuleID = "com.nimbusds" % "nimbus-jose-jwt" % Version.NimbusJoseJwt
 
-  final val Logback: ModuleID = "ch.qos.logback" % "logback-classic" % Version.Logback exclude("org.slf4", "slf4j-api") excludeAll (ExclusionRule("javax.mail"), ExclusionRule("javax.servlet"), ExclusionRule("org.codehaus.janino"))
-  final val Logging: ModuleID = "com.typesafe.scala-logging" %% "scala-logging" % Version.Logging excludeAll ExclusionRule("org.scala-lang")
+    final val Logback: ModuleID = "ch.qos.logback" % "logback-classic" % Version.Logback //exclude("org.slf4", "slf4j-api") excludeAll (ExclusionRule("javax.mail"), ExclusionRule("javax.servlet"), ExclusionRule("org.codehaus.janino"))
+    final val Logging: ModuleID = "com.typesafe.scala-logging" %% "scala-logging" % Version.Logging excludeAll ExclusionRule("org.scala-lang")
 
-  final val Config: ModuleID = "com.typesafe" % "config" % Version.Config
-  final val ScalaHttp: ModuleID = "org.scalaj" %% "scalaj-http" % Version.ScalaHttp excludeAll ExclusionRule("org.scala-lang")
-  final val Xml: ModuleID = "org.scala-lang.modules" %% "scala-xml" % Version.Xml
+    final val Config: ModuleID = "com.typesafe" % "config" % Version.Config
+    final val ScalaSttp: ModuleID = "com.softwaremill.sttp.client4" %% "core" % Version.ScalaSttp excludeAll ExclusionRule("org.scala-lang")
+    final val ScalaSttpOkHttp: ModuleID = "com.softwaremill.sttp.client4" %% "okhttp-backend" % Version.ScalaSttp excludeAll ExclusionRule("org.scala-lang")
+    final val ScalaSttpJsoniter: ModuleID = "com.softwaremill.sttp.client4" %% "jsoniter" % Version.ScalaSttp excludeAll ExclusionRule("org.scala-lang")
+    final val Xml: ModuleID = "org.scala-lang.modules" %% "scala-xml" % Version.Xml
 
-  final val NettyCodec: ModuleID = "io.netty" % "netty-codec" % Version.Netty
-  final val NettyHandler: ModuleID = "io.netty" % "netty-handler" % Version.Netty
+    final val NettyCodec: ModuleID = "io.netty" % "netty-codec" % Version.Netty
+    final val NettyHandler: ModuleID = "io.netty" % "netty-handler" % Version.Netty
 
-  object All {
-    final val Netty: Seq[ModuleID] = Seq(Deps.NettyCodec, Deps.NettyHandler)
-    final val Jsoniter: Seq[ModuleID] = Seq(Deps.Jsoniter, Deps.JsoniterMacros)
-    final val Logging: Seq[ModuleID] = Seq(Deps.Logging, Deps.Logback)
-  }
+    object All {
+        final val Http: Seq[ModuleID] = Seq(Deps.ScalaSttp, Deps.ScalaSttpOkHttp, Deps.ScalaSttpJsoniter, Deps.NimbusJoseJwt)
+        final val Netty: Seq[ModuleID] = Seq(Deps.NettyCodec, Deps.NettyHandler)
+        final val Jsoniter: Seq[ModuleID] = Seq(Deps.Jsoniter, Deps.JsoniterMacros)
+        final val Logging: Seq[ModuleID] = Seq(Deps.Logging, Deps.Logback)
+    }
 }
 
 object TestDeps {
-  final val ScalaTest: ModuleID = "org.scalatest" %% "scalatest" % Version.ScalaTest % Test
+    final val ScalaTest: ModuleID = "org.scalatest" %% "scalatest" % Version.ScalaTest % Test
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.3
+sbt.version=1.11.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
-addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.4" )
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.3" )
 addSbtPlugin("com.github.sbt" % "sbt-release"         % "1.4.0" )
-addSbtPlugin("org.scoverage"  % "sbt-scoverage"       % "2.2.2" )
-addSbtPlugin("com.eed3si9n"   % "sbt-assembly"        % "2.3.0" )
+addSbtPlugin("org.scoverage"  % "sbt-scoverage"       % "2.3.1" )
+addSbtPlugin("com.eed3si9n"   % "sbt-assembly"        % "2.3.1" )
 
 ThisBuild / libraryDependencySchemes ++= Seq(
-  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+    "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 )

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,13 +1,12 @@
 <configuration>
+
     <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>
-                %date{ISO8601} [%thread] (%-5level) (%logger) - %msg %n
+                %date{ISO8601} [%thread] %-5level %logger - %msg %n
             </pattern>
         </encoder>
     </appender>
-
-<!--    <logger name="cloutrix" level="debug" />-->
 
     <root level="info">
         <appender-ref ref="console"/>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -25,6 +25,7 @@ envoy {
   config.serial    = ${?ENLIGHTEN_SERIAL}
   config.username  = ${?ENLIGHTEN_USERNAME}
   config.password  = ${?ENLIGHTEN_PASSWORD}
+  config.jwt-token = ${?ENLIGHTEN_TOKEN}
 }
 
 saj {

--- a/src/main/scala/cloutrix/energy/DobissModbusTcpProxy.scala
+++ b/src/main/scala/cloutrix/energy/DobissModbusTcpProxy.scala
@@ -9,49 +9,49 @@ import com.typesafe.scalalogging.StrictLogging
 import java.util.concurrent.{Executors, ScheduledExecutorService}
 
 object DobissModbusTcpProxy extends StrictLogging {
-  logger.info("start Dobiss ModBus-TCP proxy")
+    logger.info("start Dobiss ModBus-TCP proxy")
 
-  var stop: () => Unit = () => {}
-  var awaitTermination: () => Unit = () => {}
+    var stop: () => Unit = () => {}
+    var awaitTermination: () => Unit = () => {}
 
-  def runReconfigured(reconf: Config => Config): Unit = {
-    val config = AppConfig.load(reconf(ConfigFactory.load()))
-    implicit val taskScheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
+    def runReconfigured(reconf: Config => Config): Unit = {
+        val config = AppConfig.load(reconf(ConfigFactory.load()))
+        implicit val taskScheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
 
-    val providers = Plugin.load(config.plugins: _*)
-    val dataProvider = new AccumulatingDataProvider(providers)
-    val server = new ModbusServer(
-      config,
-      new SunspecDataMapper(Map(
-        // we need to make sure the returned number is always >= 0
-        // as Dobiss can not deal with negative numbers because of a mis-interpretation on their side.
-        // SunSpec describes the registers as SIGNED, while Dobiss-NXT basically throws away the sign
-        // which would result in Dobiss-NXT showing 65526W production instead of -10W (10W consumption)
-        // ( and EnvoyS remains online during the night, showing negative values for production )
-        Sunspec.AccumulatedCurrentActivePower.address -> (() => positiveOrElse(0)(dataProvider.currentProduction + config.immediateProductionCorrection)),
-        Sunspec.TotalYieldWh.address                  -> (() => positiveOrElse(0)(dataProvider.totalProduction + config.totalProductionCorrection))
-      ))
-    )
+        val providers = Plugin.load(config.plugins: _*)
+        val dataProvider = new AccumulatingDataProvider(providers)
+        val server = new ModbusServer(
+            config,
+            new SunspecDataMapper(Map(
+                // we need to make sure the returned number is always >= 0
+                // as Dobiss can not deal with negative numbers because of a mis-interpretation on their side.
+                // SunSpec describes the registers as SIGNED, while Dobiss-NXT basically throws away the sign
+                // which would result in Dobiss-NXT showing 65526W production instead of -10W (10W consumption)
+                // ( and EnvoyS remains online during the night, showing negative values for production )
+                Sunspec.AccumulatedCurrentActivePower.address -> (() => positiveOrElse(0)(dataProvider.currentProduction + config.immediateProductionCorrection)),
+                Sunspec.TotalYieldWh.address                  -> (() => positiveOrElse(0)(dataProvider.totalProduction + config.totalProductionCorrection))
+            ))
+        )
 
-    server.start()
-    TaskScheduling.findAll(providers: _*).foreach(_.start(config.pollInterval))
+        server.start()
+        TaskScheduling.findAll(providers: _*).foreach(_.start(config.pollInterval))
 
-    stop = () => {
-      logger.info("shutdown triggered, close the application")
-      server.stop()
-      TaskScheduling.findAll(providers: _*).foreach(_.stop())
-      server.awaitTermination()
-      logger.info(s"Dobiss ModBus-TCP proxy - Bye bye!")
+        stop = () => {
+            logger.info("shutdown triggered, close the application")
+            server.stop()
+            TaskScheduling.findAll(providers: _*).foreach(_.stop())
+            server.awaitTermination()
+            logger.info(s"Dobiss ModBus-TCP proxy - Bye bye!")
+        }
+
+        awaitTermination = () => server.awaitTermination()
+        System.gc()
     }
 
-    awaitTermination = () => server.awaitTermination()
-    System.gc()
-  }
-
-  // main entry point
-  def main(args: Array[String]): Unit = {
-    runReconfigured(identity)
-    sys.addShutdownHook { stop() }
-    awaitTermination()
-  }
+    // main entry point
+    def main(args: Array[String]): Unit = {
+        runReconfigured(identity)
+        sys.addShutdownHook { stop() }
+        awaitTermination()
+    }
 }

--- a/src/main/scala/cloutrix/energy/envoy/EnvoyDataProvider.scala
+++ b/src/main/scala/cloutrix/energy/envoy/EnvoyDataProvider.scala
@@ -73,7 +73,7 @@ object EnvoyDataProvider extends StrictLogging {
         logger.info(s"request new JWT token - sessionId: $sessionId, serial: $serial, username: $username")
 
         logger.debug(s"HTTP request: ${req.toString}")
-        req.send(HttpClient.Backend) match {
+        req.send(HttpClient.SecureBackend) match {
             case resp @ Response(body, statusCode, _, _, _, _) if statusCode.isSuccess =>
                 logger.debug(s"HTTP response: ${resp.toString}")
                 Success(body)
@@ -96,7 +96,7 @@ object EnvoyDataProvider extends StrictLogging {
         logger.info(s"request new Management session - username: $username")
 
         logger.debug(s"HTTP request: ${req.toString}")
-        req.send(HttpClient.Backend) match {
+        req.send(HttpClient.SecureBackend) match {
             case resp @ Response(body, statusCode, _, _, _, _) if statusCode.isSuccess =>
                 logger.debug(s"HTTP response: ${resp.toString}")
                 Success(body.session_id)

--- a/src/main/scala/cloutrix/energy/envoy/EnvoyMeterMetadata.scala
+++ b/src/main/scala/cloutrix/energy/envoy/EnvoyMeterMetadata.scala
@@ -7,6 +7,6 @@ case class EnvoyMeterMeta(eid: Long, measurementType: String)
 case class EnvoyMeterMetas(all: Seq[EnvoyMeterMeta])
 
 object EnvoyMeterMetadata {
-  private val JsonCodec = JsonCodecMaker.make[Seq[EnvoyMeterMeta]]
-  val read : String => EnvoyMeterMetas = (raw: String) => EnvoyMeterMetas(all = readFromString(raw)(EnvoyMeterMetadata.JsonCodec))
+    private val JsonCodec = JsonCodecMaker.make[Seq[EnvoyMeterMeta]]
+    val read : String => EnvoyMeterMetas = (raw: String) => EnvoyMeterMetas(all = readFromString(raw)(EnvoyMeterMetadata.JsonCodec))
 }

--- a/src/main/scala/cloutrix/energy/envoy/EnvoyMeterReading.scala
+++ b/src/main/scala/cloutrix/energy/envoy/EnvoyMeterReading.scala
@@ -7,6 +7,6 @@ case class EnvoyMeterReading(eid: Long, activePower: Double, actEnergyDlvd: Doub
 case class EnvoyMeterReadings(all: Seq[EnvoyMeterReading])
 
 object EnvoyMeterReading {
-  private val JsonCodec = JsonCodecMaker.make[Seq[EnvoyMeterReading]]
-  val read : String => EnvoyMeterReadings = (raw: String) => EnvoyMeterReadings(all = readFromString(raw)(EnvoyMeterReading.JsonCodec))
+    private val JsonCodec = JsonCodecMaker.make[Seq[EnvoyMeterReading]]
+    val read : String => EnvoyMeterReadings = (raw: String) => EnvoyMeterReadings(all = readFromString(raw)(EnvoyMeterReading.JsonCodec))
 }

--- a/src/main/scala/cloutrix/energy/internal/AccumulatingDataProvider.scala
+++ b/src/main/scala/cloutrix/energy/internal/AccumulatingDataProvider.scala
@@ -1,7 +1,6 @@
 package cloutrix.energy.internal
 
 class AccumulatingDataProvider(providers: Seq[DataProvider]) extends DataProvider {
-  override def currentProduction: Int = providers.map(_.currentProduction).sum
-
-  override def totalProduction: Int = providers.map(_.totalProduction).sum
+    override def currentProduction: Int = providers.map(_.currentProduction).sum
+    override def totalProduction: Int = providers.map(_.totalProduction).sum
 }

--- a/src/main/scala/cloutrix/energy/internal/AppConfig.scala
+++ b/src/main/scala/cloutrix/energy/internal/AppConfig.scala
@@ -10,100 +10,100 @@ import scala.jdk.CollectionConverters.SetHasAsScala
 import scala.util.{Success, Try}
 
 class AppConfig (inner: Config) extends LazyLogging {
-  logger.debug(s"inner config:\n${inner.root().render(ConfigRenderOptions.concise().setJson(true).setFormatted(true))}")
+    logger.debug(s"inner config:\n${inner.root().render(ConfigRenderOptions.concise().setJson(true).setFormatted(true))}")
 
-  import AppConfig._
-  lazy val modbusTcpPort: Int = inner.getInt(MODBUS_TCP_PORT_CONFIG)
-  lazy val pollInterval: FiniteDuration = FiniteDuration(
-    length = inner.getDuration(POLL_INTERVAL_CONFIG).toMillis,
-    unit = TimeUnit.MILLISECONDS
-  )
+    import AppConfig._
+    lazy val modbusTcpPort: Int = inner.getInt(MODBUS_TCP_PORT_CONFIG)
+    lazy val pollInterval: FiniteDuration = FiniteDuration(
+        length = inner.getDuration(POLL_INTERVAL_CONFIG).toMillis,
+        unit = TimeUnit.MILLISECONDS
+    )
 
-  lazy val totalProductionCorrection: Int = Try(inner.getInt(CORRECTIONS_TOTAL_PRODUCTION_CONFIG)) match {
-    case Success(offset) =>
-      logger.warn(s"total production values are forcefully corrected with: ${offset}Wh")
-      offset
-    case _ => 0
-  }
+    lazy val totalProductionCorrection: Int = Try(inner.getInt(CORRECTIONS_TOTAL_PRODUCTION_CONFIG)) match {
+        case Success(offset) =>
+            logger.warn(s"total production values are forcefully corrected with: ${offset}Wh")
+            offset
+        case _ => 0
+    }
 
-  lazy val immediateProductionCorrection: Int = Try(inner.getInt(CORRECTIONS_IMMEDIATE_PRODUCTION_CONFIG)) match {
-    case Success(offset) =>
-      logger.warn(s"immediate production values are forcefully corrected with: ${offset}W")
-      offset
-    case _ => 0
-  }
+    lazy val immediateProductionCorrection: Int = Try(inner.getInt(CORRECTIONS_IMMEDIATE_PRODUCTION_CONFIG)) match {
+        case Success(offset) =>
+            logger.warn(s"immediate production values are forcefully corrected with: ${offset}W")
+            offset
+        case _ => 0
+    }
 
-  lazy val plugins: List[PluginDesc] = inner.getObject(PLUGINS_CONFIG).entrySet().asScala
-    .map { e => e.getKey -> e.getValue }
-    .map { case (name, cfg: ConfigObject) =>
-      PluginDesc(
-        name = name,
-        config = cfg.toConfig.getConfig(PLUGIN_CONFIG_BLOCK),
-        ctor = Plugin.loadClass(cfg.toConfig.getString(PLUGIN_CLASS_CONFIG))(_: Config)
-      )
-    }.toList
+    lazy val plugins: List[PluginDesc] = inner.getObject(PLUGINS_CONFIG).entrySet().asScala
+        .map { e => e.getKey -> e.getValue }
+        .map { case (name, cfg: ConfigObject) =>
+            PluginDesc(
+                name = name,
+                config = cfg.toConfig.getConfig(PLUGIN_CONFIG_BLOCK),
+                ctor = Plugin.loadClass(cfg.toConfig.getString(PLUGIN_CLASS_CONFIG))(_: Config)
+            )
+        }.toList
 }
 
 object AppConfig {
-  private final val MODBUS_TCP_PORT_CONFIG: String = "modbus.tcp.port"
-  private final val PLUGINS_CONFIG: String = "plugins"
-  private final val PLUGIN_CLASS_CONFIG: String = "class"
-  private final val PLUGIN_CONFIG_BLOCK: String = "config"
-  private final val POLL_INTERVAL_CONFIG: String = "poll.interval"
-  private final val CORRECTIONS_TOTAL_PRODUCTION_CONFIG: String = "corrections.total-production"
-  private final val CORRECTIONS_IMMEDIATE_PRODUCTION_CONFIG: String = "corrections.immediate-production"
+    private final val MODBUS_TCP_PORT_CONFIG: String = "modbus.tcp.port"
+    private final val PLUGINS_CONFIG: String = "plugins"
+    private final val PLUGIN_CLASS_CONFIG: String = "class"
+    private final val PLUGIN_CONFIG_BLOCK: String = "config"
+    private final val POLL_INTERVAL_CONFIG: String = "poll.interval"
+    private final val CORRECTIONS_TOTAL_PRODUCTION_CONFIG: String = "corrections.total-production"
+    private final val CORRECTIONS_IMMEDIATE_PRODUCTION_CONFIG: String = "corrections.immediate-production"
 
-  def load(config: Config = ConfigFactory.load(), envs: Map[String, String] = sys.env): AppConfig = {
-    var cfg = config
-    pluginConfigFromEnv(config)(envs).foreach { case id -> c =>
-      cfg = cfg.withValue(s"plugins.${id}", c.root())
+    def load(config: Config = ConfigFactory.load(), envs: Map[String, String] = sys.env): AppConfig = {
+        var cfg = config
+        pluginConfigFromEnv(config)(envs).foreach { case id -> c =>
+            cfg = cfg.withValue(s"plugins.${id}", c.root())
+        }
+
+        new AppConfig(cfg)
     }
 
-    new AppConfig(cfg)
-  }
+    /**
+     * allow plugin configuration through environment variables
+     *
+     * plugin identifier (name) is taken from the key: PLUGIN_(name)
+     * the value consists out of 3 parts:
+     *   - type of inverter: refers to the key of an existing configuration (see: reference.conf)
+     *   - ip-address
+     *   - port [optional] (default: 80)
+     *
+     * example:
+     *  PLUGIN_EnvoyS = envoy@10.0.0.1
+     *  PLUGIN_Saj1   = saj@10.0.0.2:8080
+     */
+    private def pluginConfigFromEnv(config: Config)(envs: Map[String, String]): Map[String, Config] = {
+        val keyToIdRegex = """^PLUGIN_(.*)$""".r
+        val valueRegex = """^([A-Za-z0-9_]+)@([A-za-z0-9:.]+)$""".r
 
-  /**
-   * allow plugin configuration through environment variables
-   *
-   * plugin identifier (name) is taken from the key: PLUGIN_(name)
-   * the value consists out of 3 parts:
-   *   - type of inverter: refers to the key of an existing configuration (see: reference.conf)
-   *   - ip-address
-   *   - port [optional] (default: 80)
-   *
-   * example:
-   *  PLUGIN_EnvoyS = envoy@10.0.0.1
-   *  PLUGIN_Saj1   = saj@10.0.0.2:8080
-   */
-  private def pluginConfigFromEnv(config: Config)(envs: Map[String, String]): Map[String, Config] = {
-    val keyToIdRegex = """^PLUGIN_(.*)$""".r
-    val valueRegex = """^([A-Za-z0-9_]+)@([A-za-z0-9:.]+)$""".r
+        def asURI(v: String): Option[URI] = Try(new URI("my://" + v)).toOption
 
-    def asURI(v: String): Option[URI] = Try(new URI("my://" + v)).toOption
+        //TODO: optimize!
+        envs
+            .view
+            .flatMap { case (k, v) => Some(k).collect { case keyToIdRegex(id) => id -> v } }
+            .flatMap { case (id, v) => Some(v).collect { case valueRegex(typ, inetaddr) => id -> (typ, asURI(inetaddr)) } }
+            .collect { case (id, (typ, Some(uri))) => id -> (typ, (uri.getHost -> uri.getPort)) }
+            .map { case (id, (typ, (host, port))) => id -> (config.getConfig(typ), (host -> port)) }
+            .map {
+                case (id, (cfg, (host, port))) if port == 443 =>
+                    id -> cfg
+                        .withValue("config.host", ConfigValueFactory.fromAnyRef(host))
+                        .withValue("config.port", ConfigValueFactory.fromAnyRef(Int.box(port)))
+                        .withValue("config.tls", ConfigValueFactory.fromAnyRef(Boolean.box(true)))
 
-    //TODO: optimize!
-    envs
-      .view
-      .flatMap { case (k, v) => Some(k).collect { case keyToIdRegex(id) => id -> v } }
-      .flatMap { case (id, v) => Some(v).collect { case valueRegex(typ, inetaddr) => id -> (typ, asURI(inetaddr)) } }
-      .collect { case (id, (typ, Some(uri))) => id -> (typ, (uri.getHost -> uri.getPort)) }
-      .map { case (id, (typ, (host, port))) => id -> (config.getConfig(typ), (host -> port)) }
-      .map {
-        case (id, (cfg, (host, port))) if port == 443 =>
-          id -> cfg
-            .withValue("config.host", ConfigValueFactory.fromAnyRef(host))
-            .withValue("config.port", ConfigValueFactory.fromAnyRef(Int.box(port)))
-            .withValue("config.tls", ConfigValueFactory.fromAnyRef(Boolean.box(true)))
+                case (id, (cfg, (host, port))) if port > 0 =>
+                    id -> cfg
+                        .withValue("config.host", ConfigValueFactory.fromAnyRef(host))
+                        .withValue("config.port", ConfigValueFactory.fromAnyRef(Int.box(port)))
 
-        case (id, (cfg, (host, port))) if port > 0 =>
-          id -> cfg
-            .withValue("config.host", ConfigValueFactory.fromAnyRef(host))
-            .withValue("config.port", ConfigValueFactory.fromAnyRef(Int.box(port)))
+                case (id, (cfg, (host, _))) =>
+                    id -> cfg
+                        .withValue("config.host", ConfigValueFactory.fromAnyRef(host))
 
-        case (id, (cfg, (host, _))) =>
-          id -> cfg
-            .withValue("config.host", ConfigValueFactory.fromAnyRef(host))
-
-      }.toMap
-  }
+            }.toMap
+    }
 }

--- a/src/main/scala/cloutrix/energy/internal/DataProvider.scala
+++ b/src/main/scala/cloutrix/energy/internal/DataProvider.scala
@@ -1,6 +1,6 @@
 package cloutrix.energy.internal
 
 trait DataProvider {
-  def currentProduction: Int    // unsigned int  (**MUST** be positive)
-  def totalProduction: Int      // unsigned int  (**MUST** be positive)
+    def currentProduction: Int    // unsigned int  (**MUST** be positive)
+    def totalProduction: Int      // unsigned int  (**MUST** be positive)
 }

--- a/src/main/scala/cloutrix/energy/internal/DataProviderCache.scala
+++ b/src/main/scala/cloutrix/energy/internal/DataProviderCache.scala
@@ -1,15 +1,14 @@
 package cloutrix.energy.internal
 
 trait DataProviderCache extends DataProvider {
-  private var cp: Option[Int] = None
-  private var tp: Option[Int] = None
+    private var cp: Option[Int] = None
+    private var tp: Option[Int] = None
 
-  def cache(currentProduction: Option[Int] = None, totalProduction: Option[Int] = None): Unit = {
-    currentProduction.map(Some(_)).foreach(cp = _)
-    totalProduction.map(Some(_)).foreach(tp = _)
-  }
+    def cache(currentProduction: Option[Int] = None, totalProduction: Option[Int] = None): Unit = {
+        currentProduction.map(Some(_)).foreach(cp = _)
+        totalProduction.map(Some(_)).foreach(tp = _)
+    }
 
-  override def currentProduction: Int = cp.getOrElse( throw new IllegalStateException("production data not yet available") )
-
-  override def totalProduction: Int = tp.getOrElse( throw new IllegalStateException("production data not yet available") )
+    override def currentProduction: Int = cp.getOrElse( throw new IllegalStateException("production data not yet available") )
+    override def totalProduction: Int = tp.getOrElse( throw new IllegalStateException("production data not yet available") )
 }

--- a/src/main/scala/cloutrix/energy/internal/HttpClient.scala
+++ b/src/main/scala/cloutrix/energy/internal/HttpClient.scala
@@ -1,50 +1,55 @@
 package cloutrix.energy.internal
 
 import com.typesafe.scalalogging.LazyLogging
-import scalaj.http.{Http, HttpOptions, HttpRequest, HttpResponse}
+import sttp.client4.okhttp.OkHttpSyncBackend
+import sttp.client4.{Request, Response, asStringAlways, basicRequest}
+import sttp.model.Uri
 
-import java.net.URL
-import scala.Option.option2Iterable
-import scala.collection.IterableOnce.iterableOnceExtensionMethods
 import scala.concurrent.duration.{Duration, DurationInt}
-import scala.util.chaining.scalaUtilChainingOps
 
 case class HttpConfig(
-                       host: String,
-                       port: Int,
-                       connectionTimeout: Duration = HttpClient.DefaultConnectionTimeout,
-                       readTimeout: Duration = HttpClient.DefaultReadTimeout,
-                       tls: Boolean = false
+                         host: String,
+                         port: Int,
+                         connectionTimeout: Duration = HttpClient.DefaultConnectionTimeout,
+                         readTimeout: Duration = HttpClient.DefaultReadTimeout,
+                         tls: Boolean = false
                      )
 
 object HttpClient {
-  final val DefaultConnectionTimeout: Duration = 10.seconds
-  final val DefaultReadTimeout: Duration = 10.seconds
+    final val DefaultConnectionTimeout: Duration = 10.seconds
+    final val DefaultReadTimeout: Duration = 10.seconds
+    final val Backend = OkHttpSyncBackend()
 }
 
+class HttpStatusException(msg: String) extends RuntimeException(s"HTTP failure: $msg")
+
 trait HttpClient extends LazyLogging {
-  protected def on401(): Unit = {}
+    protected def on401(): Unit = {}
+    protected def addCustomHeaders[T](req: Request[T]): Request[T] = req
 
-  protected def addCustomHeaders(req: HttpRequest): HttpRequest = req
+    protected def uriFor(path: String)(implicit config: HttpConfig): Uri =
+        Uri(
+            scheme = if (config.tls) "https" else "http",
+            host   = config.host,
+            port   = config.port,
+            path   = path.split('/')
+        )
 
-  protected def urlFor(path: String)(implicit config: HttpConfig): URL = Some(new URL(if (config.tls) "https" else "http", config.host, config.port, path))
-    .tapEach(url => logger.debug(s"HTTP URL: ${url.toString}"))
-    .head
+    protected def doHttpRequest[T](path: String, reader: String => T)(implicit config: HttpConfig): Option[T] = {
+        val req =
+            addCustomHeaders(basicRequest
+                .readTimeout(config.readTimeout)
+                //.options(HttpOptions.allowUnsafeSSL)
+                .get(uriFor(path))
+                .response(asStringAlways))
 
-  protected def reqFor(url: URL)(implicit config: HttpConfig): HttpRequest = Http(url.toString)
-    .timeout(config.connectionTimeout.toMillis.toInt, config.readTimeout.toMillis.toInt)
-    .options(HttpOptions.allowUnsafeSSL)
-
-  protected def doHttpRequest[T](path: String, reader: String => T)(implicit config: HttpConfig): Option[T] = {
-    Some(reqFor(urlFor(path)))
-      .tapEach(req => logger.debug(s"HTTP REQUEST: ${req.toString}"))
-      .map(addCustomHeaders(_).asString)
-      .flatMap {
-        case HttpResponse(_, 401, _) => on401(); None
-        case resp if resp.is2xx => Some(reader(resp.body))
-        case resp =>
-          logger.error(s"error executing HTTP request - response-code: ${resp.code}")
-          None
-      }.headOption
-  }
+        logger.debug(s"HTTP request: ${req.toString}")
+        req.send(HttpClient.Backend) match {
+            case Response (   _, code, _, _, _, _) if code.code == 401 => on401(); None
+            case Response (body, code, _, _, _, _) if code.isSuccess   => Some(reader(body))
+            case resp =>
+                logger.error(s"error executing HTTP request - ${resp.toString}")
+                None
+        }
+    }
 }

--- a/src/main/scala/cloutrix/energy/internal/HttpDataPoller.scala
+++ b/src/main/scala/cloutrix/energy/internal/HttpDataPoller.scala
@@ -8,71 +8,67 @@ import scala.util.Try
 import scala.util.chaining.scalaUtilChainingOps
 
 abstract class HttpDataPoller extends ScheduledDataPoller with HttpClient with LazyLogging {
-  private var actions = Map.empty[String, (Runnable, Boolean)]
-  private var tasks = Map.empty[String, ScheduledFuture[_]]
+    private var actions = Map.empty[String, (Runnable, Boolean)]
+    private var tasks = Map.empty[String, ScheduledFuture[_]]
 
-  private var scheduleAction: (String, Runnable) => (String, ScheduledFuture[_]) = (_, _) => throw new IllegalStateException("Poller not started")
+    private var scheduleAction: (String, Runnable) => (String, ScheduledFuture[_]) = (_, _) => throw new IllegalStateException("Poller not started")
 
-  final override def start(interval: FiniteDuration)(implicit es: ScheduledExecutorService): Unit = {
-    scheduleAction = (id: String, task: Runnable) => {
-      logger.debug(s"schedule task - id: ${id}, interval: ${interval.toCoarsest.toString()}")
-      id -> es.scheduleAtFixedRate(task, 0, interval.length, interval.unit)
+    final override def start(interval: FiniteDuration)(implicit es: ScheduledExecutorService): Unit = {
+        scheduleAction = (id: String, task: Runnable) => {
+            logger.debug(s"schedule task - id: ${id}, interval: ${interval.toCoarsest.toString()}")
+            id -> es.scheduleAtFixedRate(task, 0, interval.length, interval.unit)
+        }
+
+        tasks = actions
+            .withFilter { case (_, (_, autoStart)) => autoStart }
+            .map { case (id, (task, _)) =>
+                scheduleAction(id, task)
+            }
+
+        onStart()
     }
 
-    tasks = actions
-              .withFilter { case (_, (_, autoStart)) => autoStart }
-              .map { case (id, (task, _)) =>
-                 scheduleAction(id, task)
-              }
-
-    onStart()
-  }
-
-  final override def stop(): Unit = {
-    tasks.keys.foreach(cancelTask)
-    tasks = Map.empty
-    onStop()
-  }
-
-  final protected def cancelTask(id: String): Unit = {
-    tasks
-      .get(id)
-      .map(_.cancel(true))
-      .tap(s => logger.debug(s"canceled task - id: ${id}, status: ${s.isDefined}"))
-      .tapEach(_ => tasks -= id)
-      .head
-  }
-
-  final protected def startTask(id: String): Boolean = {
-    if (tasks.contains(id)) return false  // already scheduled
-
-    actions
-      .get(id)
-      .map { case (task, _) => scheduleAction(id, task) }
-      .tapEach(tasks += _)
-      .nonEmpty
-  }
-
-  final protected def register[T](action: (String, (String, String => T)), autoStart: Boolean = true)(implicit httpConfig: HttpConfig): Unit = {
-    val (id, (path, codec)) = action
-    def task: Runnable = {
-      def onDataLogged(id: String, data: Any): Unit = {
-        logger.debug(s"got data - id: ${id}, path: ${path}, data: ${data}")
-        onData(id, doHttpRequest(path, codec))
-      }
-
-      () => Try(onDataLogged(id, doHttpRequest(path, codec)))
-              .recover { case err: Throwable => onError(err) }
+    final override def stop(): Unit = {
+        tasks.keys.foreach(cancelTask)
+        tasks = Map.empty
+        onStop()
     }
 
-    actions += (id -> (task, autoStart))
-  }
+    final protected def cancelTask(id: String): Unit = {
+        tasks
+            .get(id)
+            .map(_.cancel(true))
+            .tap(s => logger.debug(s"canceled task - id: ${id}, status: ${s.isDefined}"))
+            .tapEach(_ => tasks -= id)
+            .head
+    }
 
-  protected def onStart(): Unit = {}
+    final protected def startTask(id: String): Boolean = {
+        if (tasks.contains(id)) return false  // already scheduled
+        actions
+            .get(id)
+            .map { case (task, _) => scheduleAction(id, task) }
+            .tapEach(tasks += _)
+            .nonEmpty
+    }
 
-  protected def onStop(): Unit = {}
+    final protected def register[T](action: (String, (String, String => T)), autoStart: Boolean = true)(implicit httpConfig: HttpConfig): Unit = {
+        val (id, (path, codec)) = action
+        def task: Runnable = {
+            def onDataLogged(id: String, data: Any): Unit = {
+                logger.debug(s"got data - id: ${id}, path: ${path}, data: ${data}")
+                onData(id, doHttpRequest(path, codec))
+            }
 
-  protected def onError(cause: Throwable): Unit = logger.error(s"Unhandled error: ${cause.toString}", cause)
+            () => Try(onDataLogged(id, doHttpRequest(path, codec)))
+                .recover { case err: Throwable => onError(err) }
+        }
 
-  protected def onData(id: String, data: Option[Any]): Unit
+        actions += (id -> (task, autoStart))
+    }
+
+    protected def onStart(): Unit = {}
+    protected def onStop(): Unit = {}
+    protected def onError(cause: Throwable): Unit = logger.error(s"Unhandled error: ${cause.toString}", cause)
+    protected def onData(id: String, data: Option[Any]): Unit
 }

--- a/src/main/scala/cloutrix/energy/internal/InPlaceEncoding.scala
+++ b/src/main/scala/cloutrix/energy/internal/InPlaceEncoding.scala
@@ -4,6 +4,6 @@ import io.netty.buffer.ByteBuf
 import io.netty.channel.ChannelHandlerContext
 
 trait InPlaceEncoding {
-  final def encode(ctx: ChannelHandlerContext)(buf: ByteBuf = ctx.alloc().buffer()): ByteBuf = writeBuffer(buf)
-  def writeBuffer(buf: ByteBuf): ByteBuf = buf
+    final def encode(ctx: ChannelHandlerContext)(buf: ByteBuf = ctx.alloc().buffer()): ByteBuf = writeBuffer(buf)
+    def writeBuffer(buf: ByteBuf): ByteBuf = buf
 }

--- a/src/main/scala/cloutrix/energy/internal/ModbusServer.scala
+++ b/src/main/scala/cloutrix/energy/internal/ModbusServer.scala
@@ -5,9 +5,9 @@ import cloutrix.energy.sunspec.SunspecDataMapper
 import com.typesafe.scalalogging.LazyLogging
 import io.netty.bootstrap.ServerBootstrap
 import io.netty.buffer.PooledByteBufAllocator
-import io.netty.channel.nio.NioEventLoopGroup
+import io.netty.channel.nio.NioIoHandler
 import io.netty.channel.socket.nio.NioServerSocketChannel
-import io.netty.channel.{Channel, ChannelFuture, ChannelOption, EventLoopGroup}
+import io.netty.channel.{Channel, ChannelFuture, ChannelOption, EventLoopGroup, MultiThreadIoEventLoopGroup}
 
 import java.util.concurrent.TimeUnit
 
@@ -15,43 +15,44 @@ import java.util.concurrent.TimeUnit
  *
  */
 class ModbusServer(config: AppConfig, sunspecMappings: SunspecDataMapper) extends LazyLogging {
-  private val bossGroup: EventLoopGroup = new NioEventLoopGroup(1)
-  private val workerGroup: EventLoopGroup = bossGroup
+    private val bossGroup: EventLoopGroup = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory())
+    private val workerGroup: EventLoopGroup = bossGroup
 
-  private var serverChannel: Channel = _
+    private var serverChannel: Channel = _
 
-  def shutdownWorkers(): Unit = {
-    bossGroup.shutdownGracefully()
-    workerGroup.shutdownGracefully()
-  }
+    def shutdownWorkers(): Unit = {
+        bossGroup.shutdownGracefully()
+        workerGroup.shutdownGracefully()
+    }
 
-  def createServiceListener(sunspecMappings: SunspecDataMapper): ServerBootstrap = {
-    new ServerBootstrap()
-      .group(bossGroup, workerGroup)
-      .channel(classOf[NioServerSocketChannel])
-      .option(ChannelOption.SO_BACKLOG, Int.box(4))
-      .childOption(ChannelOption.SO_KEEPALIVE, Boolean.box(true))
-      .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
-      .childHandler(new ModbusChannelInitializer(sunspecMappings))
-  }
-  def start(): Unit = {
-    serverChannel = createServiceListener(sunspecMappings)
-      .bind(config.modbusTcpPort)
-      .sync()
-      .channel()
+    def createServiceListener(sunspecMappings: SunspecDataMapper): ServerBootstrap = {
+        new ServerBootstrap()
+            .group(bossGroup, workerGroup)
+            .channel(classOf[NioServerSocketChannel])
+            .option(ChannelOption.SO_BACKLOG, Int.box(4))
+            .childOption(ChannelOption.SO_KEEPALIVE, Boolean.box(true))
+            .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
+            .childHandler(new ModbusChannelInitializer(sunspecMappings))
+    }
 
-    serverChannel.closeFuture().addListener((f: ChannelFuture) => {
-      logger.info(s"service channel ${f.channel().localAddress()} closed - shutting down service")
-      shutdownWorkers()
-    })
+    def start(): Unit = {
+        serverChannel = createServiceListener(sunspecMappings)
+            .bind(config.modbusTcpPort)
+            .sync()
+            .channel()
 
-    logger.info(s"Modbus-TCP server running on channel: ${serverChannel}")
-  }
+        serverChannel.closeFuture().addListener((f: ChannelFuture) => {
+            logger.info(s"service channel ${f.channel().localAddress()} closed - shutting down service")
+            shutdownWorkers()
+        })
 
-  def stop(): Unit = {
-    logger.info("stop server on user request")
-    serverChannel.close().awaitUninterruptibly()
-  }
+        logger.info(s"Modbus-TCP server running on channel: ${serverChannel}")
+    }
 
-  def awaitTermination(): Unit = try { workerGroup.awaitTermination(Long.MaxValue, TimeUnit.NANOSECONDS) } catch { case _: InterruptedException => }
+    def stop(): Unit = {
+        logger.info("stop server on user request")
+        serverChannel.close().awaitUninterruptibly()
+    }
+
+    def awaitTermination(): Unit = try { workerGroup.awaitTermination(Long.MaxValue, TimeUnit.NANOSECONDS) } catch { case _: InterruptedException => }
 }

--- a/src/main/scala/cloutrix/energy/internal/Plugin.scala
+++ b/src/main/scala/cloutrix/energy/internal/Plugin.scala
@@ -6,17 +6,17 @@ import com.typesafe.scalalogging.StrictLogging
 case class PluginDesc(name: String, config: Config, ctor: Config => DataProvider)
 
 object Plugin extends StrictLogging {
-  def loadClass(clazz: String): Config => DataProvider = {
-    val ctor = Class.forName(clazz).getDeclaredConstructor(classOf[Config])
-    logger.info(s"loaded plugin - class: ${ctor.getName}")
+    def loadClass(clazz: String): Config => DataProvider = {
+        val ctor = Class.forName(clazz).getDeclaredConstructor(classOf[Config])
+        logger.info(s"loaded plugin - class: ${ctor.getName}")
 
-    config => ctor
-               .newInstance(config)
-               .asInstanceOf[DataProvider]
-  }
+        config => ctor
+            .newInstance(config)
+            .asInstanceOf[DataProvider]
+    }
 
-  def load(pluginDescs: PluginDesc*): Seq[DataProvider] =
-    pluginDescs
-      .tapEach(ps => logger.info(s"activate plugin - name: ${ps.name}"))
-      .map(desc => desc.ctor(desc.config))
+    def load(pluginDescs: PluginDesc*): Seq[DataProvider] =
+        pluginDescs
+            .tapEach(ps => logger.info(s"activate plugin - name: ${ps.name}"))
+            .map(desc => desc.ctor(desc.config))
 }

--- a/src/main/scala/cloutrix/energy/internal/TaskScheduling.scala
+++ b/src/main/scala/cloutrix/energy/internal/TaskScheduling.scala
@@ -4,14 +4,14 @@ import java.util.concurrent.ScheduledExecutorService
 import scala.concurrent.duration.FiniteDuration
 
 trait CanWaitForTermination {
-  def awaitTermination(): Unit = ()
+    def awaitTermination(): Unit = ()
 }
 
 trait TaskScheduling extends CanWaitForTermination {
-  def start(interval: FiniteDuration)(implicit es: ScheduledExecutorService): Unit
-  def stop(): Unit
+    def start(interval: FiniteDuration)(implicit es: ScheduledExecutorService): Unit
+    def stop(): Unit
 }
 
 object TaskScheduling {
-  def findAll(objs: Any*): Seq[TaskScheduling] = objs.collect { case s: TaskScheduling => s }
+    def findAll(objs: Any*): Seq[TaskScheduling] = objs.collect { case s: TaskScheduling => s }
 }

--- a/src/main/scala/cloutrix/energy/internal/Utils.scala
+++ b/src/main/scala/cloutrix/energy/internal/Utils.scala
@@ -1,7 +1,7 @@
 package cloutrix.energy.internal
 
 object Utils {
-  def positiveOrElse(default: Int)(vF: => Int): Int = Option(vF)
-                                                        .filter(_ > 0)
-                                                        .getOrElse(default)
+    def positiveOrElse(default: Int)(vF: => Int): Int = Option(vF)
+                                                            .filter(_ > 0)
+                                                            .getOrElse(default)
 }

--- a/src/main/scala/cloutrix/energy/modbus/ModbusFrame.scala
+++ b/src/main/scala/cloutrix/energy/modbus/ModbusFrame.scala
@@ -4,18 +4,18 @@ import cloutrix.energy.internal.InPlaceEncoding
 import io.netty.buffer.ByteBuf
 
 case class ModbusFrame(header: ModbusHeader, function: ModbusFunction with InPlaceEncoding) extends InPlaceEncoding {
-  override def writeBuffer(buf: ByteBuf): ByteBuf =
-    Option(buf)
-      .map(header.writeBuffer)
-      .map(function.writeBuffer)
-      .getOrElse(
-        throw new IllegalStateException("unable to encode Modbus frame")
-      )
+    override def writeBuffer(buf: ByteBuf): ByteBuf =
+        Option(buf)
+            .map(header.writeBuffer)
+            .map(function.writeBuffer)
+            .getOrElse(
+                throw new IllegalStateException("unable to encode Modbus frame")
+            )
 }
 
 object ModbusFrame  {
-  def decode(buf: ByteBuf): ModbusFrame = ModbusFrame(
-    header   = ModbusHeader(buf),
-    function = ModbusFunction(buf)
-  )
+    def decode(buf: ByteBuf): ModbusFrame = ModbusFrame(
+        header   = ModbusHeader(buf),
+        function = ModbusFunction(buf)
+    )
 }

--- a/src/main/scala/cloutrix/energy/modbus/ModbusFunction.scala
+++ b/src/main/scala/cloutrix/energy/modbus/ModbusFunction.scala
@@ -8,15 +8,15 @@ import io.netty.buffer.ByteBuf
 abstract class ModbusFunction(val code: Byte) extends InPlaceEncoding
 
 object ModbusFunction extends LazyLogging {
-  def apply[T >: ModbusFunction](buf: ByteBuf): T = {
-    buf.readUnsignedByte() match {
-      case 0x03 => ReadHoldingRegisters(
-        address  = buf.readShort(),
-        quantity = buf.readShort()
-      )
+    def apply[T >: ModbusFunction](buf: ByteBuf): T = {
+        buf.readUnsignedByte() match {
+            case 0x03 => ReadHoldingRegisters(
+                address  = buf.readShort(),
+                quantity = buf.readShort()
+            )
 
-      case code =>
-        throw new IllegalArgumentException(s"unsupported function code: ${code}")
+            case code =>
+                throw new IllegalArgumentException(s"unsupported function code: ${code}")
+        }
     }
-  }
 }

--- a/src/main/scala/cloutrix/energy/modbus/ModbusHeader.scala
+++ b/src/main/scala/cloutrix/energy/modbus/ModbusHeader.scala
@@ -4,21 +4,21 @@ import cloutrix.energy.internal.InPlaceEncoding
 import io.netty.buffer.ByteBuf
 
 case class ModbusHeader(transactionId: Int, protocolId: Int, pduLength: Int, unitId: Short) extends InPlaceEncoding {
-  def length: Int = pduLength + 1   //+ unit identifier
+    def length: Int = pduLength + 1   //+ unit identifier
 
-  override def writeBuffer(buf: ByteBuf): ByteBuf =
-    buf
-      .writeShort(transactionId)
-      .writeShort(protocolId)
-      .writeShort(length)
-      .writeByte(unitId)
+    override def writeBuffer(buf: ByteBuf): ByteBuf =
+        buf
+            .writeShort(transactionId)
+            .writeShort(protocolId)
+            .writeShort(length)
+            .writeByte(unitId)
 }
 
 object ModbusHeader  {
-  def apply(buf: ByteBuf): ModbusHeader = ModbusHeader(
-    transactionId = buf.readUnsignedShort(),
-    protocolId    = buf.readUnsignedShort(),
-    pduLength     = buf.readUnsignedShort(),
-    unitId        = buf.readUnsignedByte()
-  )
+    def apply(buf: ByteBuf): ModbusHeader = ModbusHeader(
+        transactionId = buf.readUnsignedShort(),
+        protocolId    = buf.readUnsignedShort(),
+        pduLength     = buf.readUnsignedShort(),
+        unitId        = buf.readUnsignedByte()
+    )
 }

--- a/src/main/scala/cloutrix/energy/modbus/functions/ReadHoldingRegisters.scala
+++ b/src/main/scala/cloutrix/energy/modbus/functions/ReadHoldingRegisters.scala
@@ -6,11 +6,11 @@ import io.netty.buffer.ByteBuf
 case class ReadHoldingRegisters(address: Int, quantity: Int) extends ModbusFunction(0x03)
 
 case class ReadHoldingRegistersResponse(value: Int) extends ModbusFunction(0x03) {
-  def calculatedLength: Int = 1 + 1 + 4
+    def calculatedLength: Int = 1 + 1 + 4
 
-  override def writeBuffer(buf: ByteBuf): ByteBuf =
-    buf
-      .writeByte(code)
-      .writeByte(4)
-      .writeInt(value)
+    override def writeBuffer(buf: ByteBuf): ByteBuf =
+        buf
+         .writeByte(code)
+         .writeByte(4)
+         .writeInt(value)
 }

--- a/src/main/scala/cloutrix/energy/modbus/handlers/ModbusChannelInitializer.scala
+++ b/src/main/scala/cloutrix/energy/modbus/handlers/ModbusChannelInitializer.scala
@@ -7,15 +7,14 @@ import io.netty.channel.{Channel, ChannelInitializer}
 import io.netty.handler.timeout.IdleStateHandler
 
 class ModbusChannelInitializer(sunspecMappings: SunspecDataMapper) extends ChannelInitializer[Channel] with LazyLogging {
-  override def initChannel(ch: Channel): Unit = {
-    logger.debug(s"new connection - channel: ${ch}")
+    override def initChannel(ch: Channel): Unit = {
+        logger.debug(s"new connection - channel: ${ch}")
 
-    ch.pipeline()
-      .addLast("modbus-framer" , new ModbusFrameDecoder)
-      .addLast("modbus-encoder", new ModbusEncoder)
-      .addLast("modbus-decoder", new ModbusDecoder)
-      .addLast("", new IdleStateHandler(10,10,0))
-      .addLast("sunspec-handler", new SunspecFunctionHandler(sunspecMappings))
-
-  }
+        ch.pipeline()
+            .addLast("modbus-framer" , new ModbusFrameDecoder)
+            .addLast("modbus-encoder", new ModbusEncoder)
+            .addLast("modbus-decoder", new ModbusDecoder)
+            .addLast("", new IdleStateHandler(10,10,0))
+            .addLast("sunspec-handler", new SunspecFunctionHandler(sunspecMappings))
+    }
 }

--- a/src/main/scala/cloutrix/energy/modbus/handlers/ModbusDecoder.scala
+++ b/src/main/scala/cloutrix/energy/modbus/handlers/ModbusDecoder.scala
@@ -9,13 +9,13 @@ import io.netty.handler.codec.ByteToMessageDecoder
 import java.util.{List => JList}
 
 class ModbusDecoder extends ByteToMessageDecoder with LazyLogging {
-  override def decode(ctx: ChannelHandlerContext, buf: ByteBuf, out: JList[AnyRef]): Unit = {
-    logger.debug(s"decode [${ctx.channel()}] - buffer: ${buf}, data: ${ByteBufUtil.hexDump(buf)}")
+    override def decode(ctx: ChannelHandlerContext, buf: ByteBuf, out: JList[AnyRef]): Unit = {
+        logger.debug(s"decode [${ctx.channel()}] - buffer: ${buf}, data: ${ByteBufUtil.hexDump(buf)}")
 
-    if(buf.readableBytes() < (Modbus.MBAP_LENGTH + 1)) return // + function code
+        if(buf.readableBytes() < (Modbus.MBAP_LENGTH + 1)) return // + function code
 
-    out.add(
-      ModbusFrame.decode(buf)
-    )
-  }
+        out.add(
+            ModbusFrame.decode(buf)
+        )
+    }
 }

--- a/src/main/scala/cloutrix/energy/modbus/handlers/ModbusEncoder.scala
+++ b/src/main/scala/cloutrix/energy/modbus/handlers/ModbusEncoder.scala
@@ -8,12 +8,12 @@ import io.netty.channel.{ChannelHandlerContext, ChannelOutboundHandlerAdapter, C
  *
  */
 class ModbusEncoder extends ChannelOutboundHandlerAdapter with LazyLogging {
-  override def write(ctx: ChannelHandlerContext, msg: Any, promise: ChannelPromise): Unit = {
-    logger.debug(s"write [${ctx.channel()}] - msg: ${msg}")
+    override def write(ctx: ChannelHandlerContext, msg: Any, promise: ChannelPromise): Unit = {
+        logger.debug(s"write [${ctx.channel()}] - msg: ${msg}")
 
-    msg match {
-      case frame: ModbusFrame => ctx.write(frame.encode(ctx)(), promise)
-      case _                  => super.write(ctx, msg, promise)
+        msg match {
+            case frame: ModbusFrame => ctx.write(frame.encode(ctx)(), promise)
+            case _                  => super.write(ctx, msg, promise)
+        }
     }
-  }
 }

--- a/src/main/scala/cloutrix/energy/saj/SajDataProvider.scala
+++ b/src/main/scala/cloutrix/energy/saj/SajDataProvider.scala
@@ -5,36 +5,36 @@ import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
 
 class SajDataProvider(config: Config) extends HttpDataPoller with DataProviderCache with LazyLogging {
-  implicit val httpConfig: HttpConfig = HttpConfig(host = config.getString("host"), port = config.getInt("port"))
+    implicit val httpConfig: HttpConfig = HttpConfig(host = config.getString("host"), port = config.getInt("port"))
 
-  register("readings" -> ("/real_time_data.xml", SajMeterReading.fromXml), autoStart = true)
+    register("readings" -> ("real_time_data.xml", SajMeterReading.fromXml), autoStart = true)
 
-  override def onError(cause: Throwable): Unit = {
-    cause match {
-      case _: java.net.NoRouteToHostException =>
-        logger.warn(s"Unable to connect to ${httpConfig.host} on port ${httpConfig.port}, assume it's off-line")
-        cache(currentProduction = Some(0))
+    override def onError(cause: Throwable): Unit = {
+        cause match {
+            case _: java.net.NoRouteToHostException =>
+                logger.warn(s"Unable to connect to ${httpConfig.host} on port ${httpConfig.port}, assume it's off-line")
+                cache(currentProduction = Some(0))
 
-      case ex: org.xml.sax.SAXParseException =>
-        logger.error(s"Error decoding XML from inverter (${httpConfig.host}:${httpConfig.port}): ${ex.getMessage}")
+            case ex: org.xml.sax.SAXParseException =>
+                logger.error(s"Error decoding XML from inverter (${httpConfig.host}:${httpConfig.port}): ${ex.getMessage}")
 
-      case _ =>
-        super.onError(cause)
+            case _ =>
+                super.onError(cause)
+        }
     }
-  }
 
-  override def onData(id: String, dataMaybe: Option[Any]): Unit = {
-    dataMaybe match {
-      case Some(dd: SajMeterReading) =>
-        logger.info(s"current production data: ${dd}")
-        // p-ac    is expressed in 'W', so OK for what Dobiss-NXT expects
-        // e-total is expressed in 'kWh', so we need to convert it to 'Wh' what Dobiss-NXT expects
-        cache(currentProduction = Some(dd.pAc.toInt), totalProduction = Some((dd.eTotal * 1000.0).toInt))
+    override def onData(id: String, dataMaybe: Option[Any]): Unit = {
+        dataMaybe match {
+            case Some(dd: SajMeterReading) =>
+                logger.info(s"current production data: ${dd}")
+                // p-ac    is expressed in 'W', so OK for what Dobiss-NXT expects
+                // e-total is expressed in 'kWh', so we need to convert it to 'Wh' what Dobiss-NXT expects
+                cache(currentProduction = Some(dd.pAc.toInt), totalProduction = Some((dd.eTotal * 1000.0).toInt))
 
-      case Some(wtf) =>
-        logger.error(s"unhandled data delivery - id: ${id}, data: ${wtf}")
+            case Some(wtf) =>
+                logger.error(s"unhandled data delivery - id: ${id}, data: ${wtf}")
 
-      case _ =>
+            case _ =>
+        }
     }
-  }
 }

--- a/src/main/scala/cloutrix/energy/saj/SajMeterReading.scala
+++ b/src/main/scala/cloutrix/energy/saj/SajMeterReading.scala
@@ -6,20 +6,20 @@ import scala.xml.{Elem, XML}
 case class SajMeterReading(pAc: Double, eTotal: Double)
 
 object SajMeterReading {
-  private final val ActivePower = "p-ac"
-  private final val TotalYield  = "e-total"
+    private final val ActivePower = "p-ac"
+    private final val TotalYield  = "e-total"
 
-  private def asDouble(xml: Elem)(nodeName: String): Double = (xml \\ nodeName).head.text.toDouble
+    private def asDouble(xml: Elem)(nodeName: String): Double = (xml \\ nodeName).head.text.toDouble
 
-  val fromXml: String => SajMeterReading = (raw) => {
-    //keep in mind: SAJ has it all ... CamelCasing, snake_casing, node-names with dashes in it, ...
-    // might not be a bad idea to convert to lowercase alphanumerics only to prevent future problems
-    // as this raises doubts in how well they comply to their own "standards" ...
-    val extract = asDouble(XML.loadString(raw))(_)
+    val fromXml: String => SajMeterReading = (raw) => {
+        //keep in mind: SAJ has it all ... CamelCasing, snake_casing, node-names with dashes in it, ...
+        // might not be a bad idea to convert to lowercase alphanumerics only to prevent future problems
+        // as this raises doubts in how well they comply to their own "standards" ...
+        val extract = asDouble(XML.loadString(raw))(_)
 
-    SajMeterReading(
-      pAc    = extract(ActivePower),
-      eTotal = extract(TotalYield)
-    )
-  }
+        SajMeterReading(
+            pAc    = extract(ActivePower),
+            eTotal = extract(TotalYield)
+        )
+    }
 }

--- a/src/main/scala/cloutrix/energy/sunspec/Sunspec.scala
+++ b/src/main/scala/cloutrix/energy/sunspec/Sunspec.scala
@@ -8,7 +8,7 @@ package cloutrix.energy.sunspec
 // ------+--------------------------------------------------+----+-----+------+----
 
 object Sunspec {
-  sealed trait Register { def address: Int }
-  final case object AccumulatedCurrentActivePower extends Register { val address = 30775 }
-  final case object TotalYieldWh                  extends Register { val address = 30529 }
+    sealed trait Register { def address: Int }
+    final case object AccumulatedCurrentActivePower extends Register { val address = 30775 }
+    final case object TotalYieldWh                  extends Register { val address = 30529 }
 }

--- a/src/main/scala/cloutrix/energy/sunspec/SunspecDataMapper.scala
+++ b/src/main/scala/cloutrix/energy/sunspec/SunspecDataMapper.scala
@@ -1,6 +1,6 @@
 package cloutrix.energy.sunspec
 
 class SunspecDataMapper(mappings: Map[Int, () => Int]) {
-  def isDefinedAt(code: Int): Boolean = mappings.contains(code)
-  def apply(code: Int): Int = mappings.getOrElse(code, throw new IllegalAccessException(s"sunspec register ${code} not mapped"))()
+    def isDefinedAt(code: Int): Boolean = mappings.contains(code)
+    def apply(code: Int): Int = mappings.getOrElse(code, throw new IllegalAccessException(s"sunspec register ${code} not mapped"))()
 }

--- a/src/main/scala/cloutrix/energy/sunspec/handlers/SunspecFunctionHandler.scala
+++ b/src/main/scala/cloutrix/energy/sunspec/handlers/SunspecFunctionHandler.scala
@@ -9,52 +9,52 @@ import io.netty.handler.timeout.IdleStateEvent
 import io.netty.util.ReferenceCountUtil
 
 class SunspecFunctionHandler(sunspecMappings: SunspecDataMapper) extends ChannelInboundHandlerAdapter with LazyLogging {
-  override def userEventTriggered(ctx: ChannelHandlerContext, evt: Any): Unit = {
-    logger.debug(s"user event received - channel:${ctx.channel()}, event:${evt}")
+    override def userEventTriggered(ctx: ChannelHandlerContext, evt: Any): Unit = {
+        logger.debug(s"user event received - channel:${ctx.channel()}, event:${evt}")
 
-    evt match {
-      case _: IdleStateEvent =>
-        logger.warn(s"nothing happening on the channel, closing it - channel:${ctx.channel()}")
-        ctx.close()
+        evt match {
+            case _: IdleStateEvent =>
+                logger.warn(s"nothing happening on the channel, closing it - channel:${ctx.channel()}")
+                ctx.close()
 
-      case _ =>
-        super.userEventTriggered(ctx, evt)
-    }
-  }
-
-  override def channelActive(ctx: ChannelHandlerContext): Unit = {
-    logger.debug(s"channel active - channel:${ctx.channel()}")
-  }
-
-  override def channelInactive(ctx: ChannelHandlerContext): Unit = {
-    logger.debug(s"channel inactive - channel:${ctx.channel()}")
-  }
-
-  override def channelRead(ctx: ChannelHandlerContext, msg: Any): Unit = {
-    logger.debug(s"channel read - channel:${ctx.channel()}, message:${msg}")
-
-    msg match {
-      case ModbusFrame(hdr, ReadHoldingRegisters(address, _)) if sunspecMappings.isDefinedAt(address) =>
-        val response = ReadHoldingRegistersResponse( sunspecMappings(address) )
-        ctx.write(
-          ModbusFrame(header = hdr.copy(pduLength = response.calculatedLength), function = response)
-        )
-
-      case _ =>
-        logger.error(s"unsupported modbus request, closing channel - message: ${msg}")
-        ctx.close()
+            case _ =>
+                super.userEventTriggered(ctx, evt)
+        }
     }
 
-    ReferenceCountUtil.release(msg)
-  }
+    override def channelActive(ctx: ChannelHandlerContext): Unit = {
+        logger.debug(s"channel active - channel:${ctx.channel()}")
+    }
 
-  override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable): Unit = {
-    logger.error(s"exception fired on channel, closing it. - channel: ${ctx.channel()}, cause: ${cause.toString}}")
-    ctx.close()
-  }
+    override def channelInactive(ctx: ChannelHandlerContext): Unit = {
+        logger.debug(s"channel inactive - channel:${ctx.channel()}")
+    }
 
-  override def channelReadComplete(ctx: ChannelHandlerContext): Unit = {
-    logger.debug(s"channel read complete - channel:${ctx.channel()}")
-    ctx.flush()
-  }
+    override def channelRead(ctx: ChannelHandlerContext, msg: Any): Unit = {
+        logger.debug(s"channel read - channel:${ctx.channel()}, message:${msg}")
+
+        msg match {
+            case ModbusFrame(hdr, ReadHoldingRegisters(address, _)) if sunspecMappings.isDefinedAt(address) =>
+                val response = ReadHoldingRegistersResponse( sunspecMappings(address) )
+                ctx.write(
+                    ModbusFrame(header = hdr.copy(pduLength = response.calculatedLength), function = response)
+                )
+
+            case _ =>
+                logger.error(s"unsupported modbus request, closing channel - message: ${msg}")
+                ctx.close()
+        }
+
+        ReferenceCountUtil.release(msg)
+    }
+
+    override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable): Unit = {
+        logger.error(s"exception fired on channel, closing it. - channel: ${ctx.channel()}, cause: ${cause.toString}}")
+        ctx.close()
+    }
+
+    override def channelReadComplete(ctx: ChannelHandlerContext): Unit = {
+        logger.debug(s"channel read complete - channel:${ctx.channel()}")
+        ctx.flush()
+    }
 }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -9,9 +9,10 @@
         </encoder>
     </appender>
 
-    <logger name="cloutrix" level="info" />
+<!--    <logger name="cloutrix" level="debug" />-->
+<!--    <logger name="testutils" level="debug" />-->
 
-    <root level="error">
+    <root level="info">
         <appender-ref ref="console"/>
     </root>
 

--- a/src/test/resources/test-app.conf
+++ b/src/test/resources/test-app.conf
@@ -10,10 +10,4 @@ plugins {
       config.host = localhost
       config.port = 80
     }
-
-    EnvoyS  {
-      class = cloutrix.energy.envoy.EnvoyDataProvider
-      config.host = localhost
-      config.port = 80
-    }
 }

--- a/src/test/resources/test-envoy-login.conf
+++ b/src/test/resources/test-envoy-login.conf
@@ -1,0 +1,12 @@
+EnvoyS  {
+  class = cloutrix.energy.envoy.EnvoyDataProvider
+  config.host = localhost
+  config.port = 80
+
+  config.tls  = false
+  config.login.url = "https://enlighten.enphaseenergy.com/login/login.json"
+  config.token.url = "https://entrez.enphaseenergy.com/tokens"
+  config.serial    = ${?ENLIGHTEN_SERIAL}
+  config.username  = ${?ENLIGHTEN_USERNAME}
+  config.password  = ${?ENLIGHTEN_PASSWORD}
+}

--- a/src/test/scala/AppOffsetCorrectionTest.scala
+++ b/src/test/scala/AppOffsetCorrectionTest.scala
@@ -11,145 +11,145 @@ import testutils.{ByteConversions, MockHttpServer, TestSockets}
 import scala.concurrent.duration.DurationInt
 
 class AppOffsetCorrectionTest extends AnyWordSpec with Matchers with BeforeAndAfterAll with TestSockets with ByteConversions with Eventually {
-  private val mockPV = new MockHttpServer
-  private lazy val listeningPort = anyFreePort
+    private val mockPV = new MockHttpServer
+    private lazy val listeningPort = anyFreePort
 
-  private val pollInterval = 1.second
-  private val waitTime = Span(pollInterval.toMillis * 2, Milliseconds)
-  private val waitInterval = waitTime.scaledBy(0.5)
+    private val pollInterval = 1.second
+    private val waitTime = Span(pollInterval.toMillis * 2, Milliseconds)
+    private val waitInterval = waitTime.scaledBy(0.5)
 
-  private def configForTest(totalProductionOffset: Int, immediateProdcutionOffset: Int) =
-    (_: Config)
-      .withValue("modbus.tcp.port", ConfigValueFactory.fromAnyRef(Int.box(listeningPort)))
-      .withValue("poll.interval", ConfigValueFactory.fromAnyRef(s"${pollInterval.toMillis} milliseconds"))
-      .withValue("corrections.total-production", ConfigValueFactory.fromAnyRef(Int.box(totalProductionOffset)))
-      .withValue("corrections.immediate-production", ConfigValueFactory.fromAnyRef(Int.box(immediateProdcutionOffset)))
-      .withValue("plugins.SAJ.class", ConfigValueFactory.fromAnyRef(classOf[cloutrix.energy.saj.SajDataProvider].getName))
-      .withValue("plugins.SAJ.config.host", ConfigValueFactory.fromAnyRef("localhost"))
-      .withValue("plugins.SAJ.config.port", ConfigValueFactory.fromAnyRef(Int.box(mockPV.port)))
+    private def configForTest(totalProductionOffset: Int, immediateProdcutionOffset: Int) =
+        (_: Config)
+            .withValue("modbus.tcp.port", ConfigValueFactory.fromAnyRef(Int.box(listeningPort)))
+            .withValue("poll.interval", ConfigValueFactory.fromAnyRef(s"${pollInterval.toMillis} milliseconds"))
+            .withValue("corrections.total-production", ConfigValueFactory.fromAnyRef(Int.box(totalProductionOffset)))
+            .withValue("corrections.immediate-production", ConfigValueFactory.fromAnyRef(Int.box(immediateProdcutionOffset)))
+            .withValue("plugins.SAJ.class", ConfigValueFactory.fromAnyRef(classOf[cloutrix.energy.saj.SajDataProvider].getName))
+            .withValue("plugins.SAJ.config.host", ConfigValueFactory.fromAnyRef("localhost"))
+            .withValue("plugins.SAJ.config.port", ConfigValueFactory.fromAnyRef(Int.box(mockPV.port)))
 
-  override def beforeAll(): Unit = {
-    (mockPV :: Nil).foreach(_.start())
-  }
-
-  override def afterAll(): Unit = {
-    (mockPV :: Nil).foreach(_.stop())
-  }
-
-  private val TotalProductionRequest = Seq(0x41, 0xf7, 0x00, 0x00, 0x00, 0x06, 0x03, 0x03, 0x77, 0x41, 0x00, 0x02).map(_.toByte).toArray
-  private val ImmediateProductionRequest = Seq(0x1d, 0x7b, 0x00, 0x00, 0x00, 0x06, 0x03, 0x03, 0x78, 0x37, 0x00, 0x02).map(_.toByte).toArray
-
-  "app modifies all meter readings with the configured offsets" when {
-    "total production correction is positive" in {
-      val runner = new Thread(() => {
-        DobissModbusTcpProxy.runReconfigured(configForTest(totalProductionOffset = 1000, immediateProdcutionOffset = 0))
-        DobissModbusTcpProxy.awaitTermination()
-      })
-
-      mockPV.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = 0.0, actEnergyDlvd = 0.0 /*kWh*/))
-      runner.start()
-
-      eventually(timeout(waitTime), interval(waitInterval)) {
-        LastInt(sendTo(listeningPort)(TotalProductionRequest, 13)) should be(1000)
-        LastInt(sendTo(listeningPort)(ImmediateProductionRequest, 13)) should be(0)
-      }
-
-      DobissModbusTcpProxy.stop()
-      runner.join()
+    override def beforeAll(): Unit = {
+        (mockPV :: Nil).foreach(_.start())
     }
 
-    "total production correction is negative" when {
-      "summed result is negative" in {
-        val runner = new Thread(() => {
-          DobissModbusTcpProxy.runReconfigured(configForTest(totalProductionOffset = -1000, immediateProdcutionOffset = 0))
-          DobissModbusTcpProxy.awaitTermination()
-        })
-
-        mockPV.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = 0.0, actEnergyDlvd = 0.0 /*kWh*/))
-        runner.start()
-
-        eventually(timeout(waitTime), interval(waitInterval)) {
-          LastInt(sendTo(listeningPort)(TotalProductionRequest, 13)) should be(0) // would be -1000, but limited to 0
-          LastInt(sendTo(listeningPort)(ImmediateProductionRequest, 13)) should be(0)
-        }
-
-        DobissModbusTcpProxy.stop()
-        runner.join()
-      }
-
-      "summed result is positive" in {
-        val runner = new Thread(() => {
-          DobissModbusTcpProxy.runReconfigured(configForTest(totalProductionOffset = -1000, immediateProdcutionOffset = 0))
-          DobissModbusTcpProxy.awaitTermination()
-        })
-
-        mockPV.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = 0.0, actEnergyDlvd = 2.5 /*kWh*/))
-        runner.start()
-
-        eventually(timeout(waitTime), interval(waitInterval)) {
-          LastInt(sendTo(listeningPort)(TotalProductionRequest, 13)) should be(1500)
-          LastInt(sendTo(listeningPort)(ImmediateProductionRequest, 13)) should be(0)
-        }
-
-        DobissModbusTcpProxy.stop()
-        runner.join()
-      }
+    override def afterAll(): Unit = {
+        (mockPV :: Nil).foreach(_.stop())
     }
 
-    "immediate production correction is positive" in {
-      val runner = new Thread(() => {
-        DobissModbusTcpProxy.runReconfigured(configForTest(totalProductionOffset = 0, immediateProdcutionOffset = 1000))
-        DobissModbusTcpProxy.awaitTermination()
-      })
+    private val TotalProductionRequest = Seq(0x41, 0xf7, 0x00, 0x00, 0x00, 0x06, 0x03, 0x03, 0x77, 0x41, 0x00, 0x02).map(_.toByte).toArray
+    private val ImmediateProductionRequest = Seq(0x1d, 0x7b, 0x00, 0x00, 0x00, 0x06, 0x03, 0x03, 0x78, 0x37, 0x00, 0x02).map(_.toByte).toArray
 
-      mockPV.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = 0.0, actEnergyDlvd = 0.0 /*kWh*/))
-      runner.start()
+    "app modifies all meter readings with the configured offsets" when {
+        "total production correction is positive" in {
+            val runner = new Thread(() => {
+                DobissModbusTcpProxy.runReconfigured(configForTest(totalProductionOffset = 1000, immediateProdcutionOffset = 0))
+                DobissModbusTcpProxy.awaitTermination()
+            })
 
-      eventually(timeout(waitTime), interval(waitInterval)) {
-        LastInt(sendTo(listeningPort)(TotalProductionRequest, 13)) should be(0)
-        LastInt(sendTo(listeningPort)(ImmediateProductionRequest, 13)) should be(1000)
-      }
+            mockPV.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = 0.0, actEnergyDlvd = 0.0 /*kWh*/))
+            runner.start()
 
-      DobissModbusTcpProxy.stop()
-      runner.join()
-    }
+            eventually(timeout(waitTime), interval(waitInterval)) {
+                LastInt(sendTo(listeningPort)(TotalProductionRequest, 13)) should be(1000)
+                LastInt(sendTo(listeningPort)(ImmediateProductionRequest, 13)) should be(0)
+            }
 
-    "immediate production correction is negative" when {
-      "summed result is negative" in {
-        val runner = new Thread(() => {
-          DobissModbusTcpProxy.runReconfigured(configForTest(totalProductionOffset = 0, immediateProdcutionOffset = -1000))
-          DobissModbusTcpProxy.awaitTermination()
-        })
-
-        mockPV.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = 0.0, actEnergyDlvd = 0.0 /*kWh*/))
-        runner.start()
-
-        eventually(timeout(waitTime), interval(waitInterval)) {
-          LastInt(sendTo(listeningPort)(TotalProductionRequest, 13)) should be(0)
-          LastInt(sendTo(listeningPort)(ImmediateProductionRequest, 13)) should be(0) // would be -1000, but limited to 0
+            DobissModbusTcpProxy.stop()
+            runner.join()
         }
 
-        DobissModbusTcpProxy.stop()
-        runner.join()
-      }
+        "total production correction is negative" when {
+            "summed result is negative" in {
+                val runner = new Thread(() => {
+                    DobissModbusTcpProxy.runReconfigured(configForTest(totalProductionOffset = -1000, immediateProdcutionOffset = 0))
+                    DobissModbusTcpProxy.awaitTermination()
+                })
 
-      "summed result is positive" in {
-        val runner = new Thread(() => {
-          DobissModbusTcpProxy.runReconfigured(configForTest(totalProductionOffset = 0, immediateProdcutionOffset = -1000))
-          DobissModbusTcpProxy.awaitTermination()
-        })
+                mockPV.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = 0.0, actEnergyDlvd = 0.0 /*kWh*/))
+                runner.start()
 
-        mockPV.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = 2500.0, actEnergyDlvd = 0.0 /*kWh*/))
-        runner.start()
+                eventually(timeout(waitTime), interval(waitInterval)) {
+                    LastInt(sendTo(listeningPort)(TotalProductionRequest, 13)) should be(0) // would be -1000, but limited to 0
+                    LastInt(sendTo(listeningPort)(ImmediateProductionRequest, 13)) should be(0)
+                }
 
-        eventually(timeout(waitTime), interval(waitInterval)) {
-          LastInt(sendTo(listeningPort)(TotalProductionRequest, 13)) should be(0)
-          LastInt(sendTo(listeningPort)(ImmediateProductionRequest, 13)) should be(1500)
+                DobissModbusTcpProxy.stop()
+                runner.join()
+            }
+
+            "summed result is positive" in {
+                val runner = new Thread(() => {
+                    DobissModbusTcpProxy.runReconfigured(configForTest(totalProductionOffset = -1000, immediateProdcutionOffset = 0))
+                    DobissModbusTcpProxy.awaitTermination()
+                })
+
+                mockPV.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = 0.0, actEnergyDlvd = 2.5 /*kWh*/))
+                runner.start()
+
+                eventually(timeout(waitTime), interval(waitInterval)) {
+                    LastInt(sendTo(listeningPort)(TotalProductionRequest, 13)) should be(1500)
+                    LastInt(sendTo(listeningPort)(ImmediateProductionRequest, 13)) should be(0)
+                }
+
+                DobissModbusTcpProxy.stop()
+                runner.join()
+            }
         }
 
-        DobissModbusTcpProxy.stop()
-        runner.join()
-      }
+        "immediate production correction is positive" in {
+            val runner = new Thread(() => {
+                DobissModbusTcpProxy.runReconfigured(configForTest(totalProductionOffset = 0, immediateProdcutionOffset = 1000))
+                DobissModbusTcpProxy.awaitTermination()
+            })
+
+            mockPV.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = 0.0, actEnergyDlvd = 0.0 /*kWh*/))
+            runner.start()
+
+            eventually(timeout(waitTime), interval(waitInterval)) {
+                LastInt(sendTo(listeningPort)(TotalProductionRequest, 13)) should be(0)
+                LastInt(sendTo(listeningPort)(ImmediateProductionRequest, 13)) should be(1000)
+            }
+
+            DobissModbusTcpProxy.stop()
+            runner.join()
+        }
+
+        "immediate production correction is negative" when {
+            "summed result is negative" in {
+                val runner = new Thread(() => {
+                    DobissModbusTcpProxy.runReconfigured(configForTest(totalProductionOffset = 0, immediateProdcutionOffset = -1000))
+                    DobissModbusTcpProxy.awaitTermination()
+                })
+
+                mockPV.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = 0.0, actEnergyDlvd = 0.0 /*kWh*/))
+                runner.start()
+
+                eventually(timeout(waitTime), interval(waitInterval)) {
+                    LastInt(sendTo(listeningPort)(TotalProductionRequest, 13)) should be(0)
+                    LastInt(sendTo(listeningPort)(ImmediateProductionRequest, 13)) should be(0) // would be -1000, but limited to 0
+                }
+
+                DobissModbusTcpProxy.stop()
+                runner.join()
+            }
+
+            "summed result is positive" in {
+                val runner = new Thread(() => {
+                    DobissModbusTcpProxy.runReconfigured(configForTest(totalProductionOffset = 0, immediateProdcutionOffset = -1000))
+                    DobissModbusTcpProxy.awaitTermination()
+                })
+
+                mockPV.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = 2500.0, actEnergyDlvd = 0.0 /*kWh*/))
+                runner.start()
+
+                eventually(timeout(waitTime), interval(waitInterval)) {
+                    LastInt(sendTo(listeningPort)(TotalProductionRequest, 13)) should be(0)
+                    LastInt(sendTo(listeningPort)(ImmediateProductionRequest, 13)) should be(1500)
+                }
+
+                DobissModbusTcpProxy.stop()
+                runner.join()
+            }
+        }
     }
-  }
 }

--- a/src/test/scala/AppUtilsTest.scala
+++ b/src/test/scala/AppUtilsTest.scala
@@ -4,34 +4,34 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class AppUtilsTest extends AnyWordSpec with Matchers {
 
-  "positiveOrDefault" should {
-    "return the input value" when {
-      "input > 0" in {
-        Utils.positiveOrElse(666)(1) should be (1)
-      }
+    "positiveOrDefault" should {
+        "return the input value" when {
+            "input > 0" in {
+                Utils.positiveOrElse(666)(1) should be (1)
+            }
 
-      "input == Int.MaxValue" in {
-        Utils.positiveOrElse(666)(Int.MaxValue) should be(Int.MaxValue)
-      }
+            "input == Int.MaxValue" in {
+                Utils.positiveOrElse(666)(Int.MaxValue) should be(Int.MaxValue)
+            }
+        }
+
+        "return the default value" when {
+            "input < 0" in {
+                Utils.positiveOrElse(666)(-1) should be (666)
+            }
+
+            "input == Int.MinValue" in {
+                Utils.positiveOrElse(666)(Int.MinValue) should be(666)
+            }
+
+            "input == 0" in {
+                Utils.positiveOrElse(666)(0) should be (666)
+            }
+
+            "input == null" in {
+                Utils.positiveOrElse(666)(null.asInstanceOf[Int]) should be (666)
+            }
+        }
     }
-
-    "return the default value" when {
-      "input < 0" in {
-        Utils.positiveOrElse(666)(-1) should be (666)
-      }
-
-      "input == Int.MinValue" in {
-        Utils.positiveOrElse(666)(Int.MinValue) should be(666)
-      }
-
-      "input == 0" in {
-        Utils.positiveOrElse(666)(0) should be (666)
-      }
-
-      "input == null" in {
-        Utils.positiveOrElse(666)(null.asInstanceOf[Int]) should be (666)
-      }
-    }
-  }
 
 }

--- a/src/test/scala/ConfigTests.scala
+++ b/src/test/scala/ConfigTests.scala
@@ -5,28 +5,28 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class ConfigTests extends AnyWordSpec with Matchers {
 
-  "configuration can be loaded" in {
-    val config = AppConfig.load(ConfigFactory.load("test-application.conf"))
+    "configuration can be loaded" in {
+        val config = AppConfig.load(ConfigFactory.load("test-app.conf"))
 
-    config.modbusTcpPort should not be 0
-    config.plugins should not be (empty)
+        config.modbusTcpPort should not be 0
+        config.plugins should not be (empty)
 
-    config.totalProductionCorrection should be (0)
-    config.immediateProductionCorrection should be (0)
-  }
+        config.totalProductionCorrection should be (0)
+        config.immediateProductionCorrection should be (0)
+    }
 
-  "plugin configuration can be done through environment variables" in {
-    val config = AppConfig.load(envs = Map(
-      "PLUGIN_xxx" -> "envoy@10.0.0.1",
-      "PLUGIN_yyy" -> "saj@10.0.0.2:8080"
-    ))
+    "plugin configuration can be done through environment variables" in {
+        val config = AppConfig.load(envs = Map(
+            "PLUGIN_xxx" -> "envoy@10.0.0.1",
+            "PLUGIN_yyy" -> "saj@10.0.0.2:8080"
+        ))
 
-    config.plugins.map(_.name) should contain theSameElementsAs Seq(
-      "xxx", "yyy"
-    )
-  }
+        config.plugins.map(_.name) should contain theSameElementsAs Seq(
+            "xxx", "yyy"
+        )
+    }
 
-  "loading plugin of unsupported type should fail" in {
-    intercept[ConfigException.Missing] (AppConfig.load(envs = Map("PLUGIN_xxx" -> "unknown@10.0.0.1")) )
-  }
+    "loading plugin of unsupported type should fail" in {
+        intercept[ConfigException.Missing] (AppConfig.load(envs = Map("PLUGIN_xxx" -> "unknown@10.0.0.1")) )
+    }
 }

--- a/src/test/scala/FullAppTest.scala
+++ b/src/test/scala/FullAppTest.scala
@@ -12,81 +12,81 @@ import testutils.{ByteConversions, MockHttpServer, TestSockets}
 import scala.concurrent.duration.DurationInt
 
 class FullAppTest extends AnyWordSpec with Matchers with BeforeAndAfterAll with TestSockets with ByteConversions with Eventually {
-  private val mockEnvoy = new MockHttpServer
-  private val mockSaj_1 = new MockHttpServer
-  private val mockSaj_2 = new MockHttpServer
+    private val mockEnvoy = new MockHttpServer
+    private val mockSaj_1 = new MockHttpServer
+    private val mockSaj_2 = new MockHttpServer
 
-  private lazy val listeningPort = anyFreePort
+    private lazy val listeningPort = anyFreePort
 
-  private val pollInterval = 1.second
-  private val waitTime = Span(pollInterval.toMillis * 2, Milliseconds)
-  private val waitInterval = waitTime.scaledBy(0.5)
+    private val pollInterval = 1.second
+    private val waitTime = Span(pollInterval.toMillis * 2, Milliseconds)
+    private val waitInterval = waitTime.scaledBy(0.5)
 
-  private val configForTest =
-    (_: Config)
-      .withValue("modbus.tcp.port", ConfigValueFactory.fromAnyRef(Int.box(listeningPort)))
-      .withValue("poll.interval", ConfigValueFactory.fromAnyRef(s"${pollInterval.toMillis} milliseconds"))
-      .withValue("plugins.SAJ-1.class", ConfigValueFactory.fromAnyRef(classOf[cloutrix.energy.saj.SajDataProvider].getName))
-      .withValue("plugins.SAJ-1.config.host", ConfigValueFactory.fromAnyRef("localhost"))
-      .withValue("plugins.SAJ-1.config.port", ConfigValueFactory.fromAnyRef(Int.box(mockSaj_1.port)))
-      .withValue("plugins.SAJ-2.class", ConfigValueFactory.fromAnyRef(classOf[cloutrix.energy.saj.SajDataProvider].getName))
-      .withValue("plugins.SAJ-2.config.host", ConfigValueFactory.fromAnyRef("localhost"))
-      .withValue("plugins.SAJ-2.config.port", ConfigValueFactory.fromAnyRef(Int.box(mockSaj_2.port)))
-      .withValue("plugins.EnvoyS.class", ConfigValueFactory.fromAnyRef(classOf[cloutrix.energy.envoy.EnvoyDataProvider].getName))
-      .withValue("plugins.EnvoyS.config.host", ConfigValueFactory.fromAnyRef("localhost"))
-      .withValue("plugins.EnvoyS.config.port", ConfigValueFactory.fromAnyRef(Int.box(mockEnvoy.port)))
+    private val configForTest =
+        (_: Config)
+            .withValue("modbus.tcp.port", ConfigValueFactory.fromAnyRef(Int.box(listeningPort)))
+            .withValue("poll.interval", ConfigValueFactory.fromAnyRef(s"${pollInterval.toMillis} milliseconds"))
+            .withValue("plugins.SAJ-1.class", ConfigValueFactory.fromAnyRef(classOf[cloutrix.energy.saj.SajDataProvider].getName))
+            .withValue("plugins.SAJ-1.config.host", ConfigValueFactory.fromAnyRef("localhost"))
+            .withValue("plugins.SAJ-1.config.port", ConfigValueFactory.fromAnyRef(Int.box(mockSaj_1.port)))
+            .withValue("plugins.SAJ-2.class", ConfigValueFactory.fromAnyRef(classOf[cloutrix.energy.saj.SajDataProvider].getName))
+            .withValue("plugins.SAJ-2.config.host", ConfigValueFactory.fromAnyRef("localhost"))
+            .withValue("plugins.SAJ-2.config.port", ConfigValueFactory.fromAnyRef(Int.box(mockSaj_2.port)))
+            .withValue("plugins.EnvoyS.class", ConfigValueFactory.fromAnyRef(classOf[cloutrix.energy.envoy.EnvoyDataProvider].getName))
+            .withValue("plugins.EnvoyS.config.host", ConfigValueFactory.fromAnyRef("localhost"))
+            .withValue("plugins.EnvoyS.config.port", ConfigValueFactory.fromAnyRef(Int.box(mockEnvoy.port)))
 
 
-  override def beforeAll(): Unit = {
-    mockEnvoy.register("/ivp/meters")(Envoy.sampleMeter)
-    mockEnvoy.register("/ivp/meters/readings")(Envoy.sampleMeterReadings(activePower = 10.0, actEnergyDlvd = 1000.0))
-    mockSaj_1.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = 20.0, actEnergyDlvd = 2.0 /*kWh*/))
-    mockSaj_2.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = 40.0, actEnergyDlvd = 4.0 /*kWh*/))
+    override def beforeAll(): Unit = {
+        mockEnvoy.register("/ivp/meters")(Envoy.sampleMeter)
+        mockEnvoy.register("/ivp/meters/readings")(Envoy.sampleMeterReadings(activePower = 10.0, actEnergyDlvd = 1000.0))
+        mockSaj_1.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = 20.0, actEnergyDlvd = 2.0 /*kWh*/))
+        mockSaj_2.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = 40.0, actEnergyDlvd = 4.0 /*kWh*/))
 
-    (mockEnvoy :: mockSaj_1 :: mockSaj_2 :: Nil).foreach(_.start())
-  }
-
-  override def afterAll(): Unit = {
-    (mockEnvoy :: mockSaj_1 :: mockSaj_2 :: Nil).foreach(_.stop())
-  }
-
-  "app can run and process modbus requests" in {
-    val runner = new Thread(() => {
-      DobissModbusTcpProxy.runReconfigured(configForTest)
-      DobissModbusTcpProxy.awaitTermination()
-    })
-
-    runner.start()
-
-    val raw30529 = Seq(0x41, 0xf7, 0x00, 0x00, 0x00, 0x06, 0x03, 0x03, 0x77, 0x41, 0x00, 0x02).map(_.toByte).toArray
-    val raw30775 = Seq(0x1d, 0x7b, 0x00, 0x00, 0x00, 0x06, 0x03, 0x03, 0x78, 0x37, 0x00, 0x02).map(_.toByte).toArray
-
-    // ERROR logs can appear here as we're issuing ModBus request while the data is not yet cached from querying the (mocked) inverters
-    // (hence the 'eventually')
-    eventually(timeout(waitTime), interval(waitInterval)) {
-      LastInt(sendTo(listeningPort)(raw30529, 13)) should be(7000)  // all actEnergyDlvd values (in Wh) summed
-      LastInt(sendTo(listeningPort)(raw30775, 13)) should be(70)    // all activePower (in W) summed
+        (mockEnvoy :: mockSaj_1 :: mockSaj_2 :: Nil).foreach(_.start())
     }
 
-    note("and properly handle negative values coming from the inverters")
-
-    mockEnvoy.register("/ivp/meters/readings")(Envoy.sampleMeterReadings(activePower = -10.0, actEnergyDlvd = 1000.0))
-    mockSaj_1.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = -10.0, actEnergyDlvd = 1.0 /*kWh*/))
-    mockSaj_2.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = -10.0, actEnergyDlvd = 1.0 /*kWh*/))
-
-    eventually(timeout(waitTime), interval(waitInterval)) {
-      LastInt(sendTo(listeningPort)(raw30775, 13)) should be(0)
+    override def afterAll(): Unit = {
+        (mockEnvoy :: mockSaj_1 :: mockSaj_2 :: Nil).foreach(_.stop())
     }
 
-    mockEnvoy.register("/ivp/meters/readings")(Envoy.sampleMeterReadings(activePower = -10.0, actEnergyDlvd = 1000.0))
-    mockSaj_1.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower =  5.0, actEnergyDlvd = 1.0 /*kWh*/))
-    mockSaj_2.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = 10.0, actEnergyDlvd = 1.0 /*kWh*/))
+    "app can run and process modbus requests" in {
+        val runner = new Thread(() => {
+            DobissModbusTcpProxy.runReconfigured(configForTest)
+            DobissModbusTcpProxy.awaitTermination()
+        })
 
-    eventually(timeout(waitTime), interval(waitInterval)) {
-      LastInt(sendTo(listeningPort)(raw30775, 13)) should be(5)
+        runner.start()
+
+        val raw30529 = Seq(0x41, 0xf7, 0x00, 0x00, 0x00, 0x06, 0x03, 0x03, 0x77, 0x41, 0x00, 0x02).map(_.toByte).toArray
+        val raw30775 = Seq(0x1d, 0x7b, 0x00, 0x00, 0x00, 0x06, 0x03, 0x03, 0x78, 0x37, 0x00, 0x02).map(_.toByte).toArray
+
+        // ERROR logs can appear here as we're issuing ModBus request while the data is not yet cached from querying the (mocked) inverters
+        // (hence the 'eventually')
+        eventually(timeout(waitTime), interval(waitInterval)) {
+            LastInt(sendTo(listeningPort)(raw30529, 13)) should be(7000)  // all actEnergyDlvd values (in Wh) summed
+            LastInt(sendTo(listeningPort)(raw30775, 13)) should be(70)    // all activePower (in W) summed
+        }
+
+        note("and properly handle negative values coming from the inverters")
+
+        mockEnvoy.register("/ivp/meters/readings")(Envoy.sampleMeterReadings(activePower = -10.0, actEnergyDlvd = 1000.0))
+        mockSaj_1.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = -10.0, actEnergyDlvd = 1.0 /*kWh*/))
+        mockSaj_2.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = -10.0, actEnergyDlvd = 1.0 /*kWh*/))
+
+        eventually(timeout(waitTime), interval(waitInterval)) {
+            LastInt(sendTo(listeningPort)(raw30775, 13)) should be(0)
+        }
+
+        mockEnvoy.register("/ivp/meters/readings")(Envoy.sampleMeterReadings(activePower = -10.0, actEnergyDlvd = 1000.0))
+        mockSaj_1.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower =  5.0, actEnergyDlvd = 1.0 /*kWh*/))
+        mockSaj_2.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = 10.0, actEnergyDlvd = 1.0 /*kWh*/))
+
+        eventually(timeout(waitTime), interval(waitInterval)) {
+            LastInt(sendTo(listeningPort)(raw30775, 13)) should be(5)
+        }
+
+        DobissModbusTcpProxy.stop()
+        runner.join()
     }
-
-    DobissModbusTcpProxy.stop()
-    runner.join()
-  }
 }

--- a/src/test/scala/envoy/DataProviderTests.scala
+++ b/src/test/scala/envoy/DataProviderTests.scala
@@ -14,51 +14,51 @@ import java.util.concurrent.{Executors, ScheduledExecutorService}
 import scala.concurrent.duration.DurationInt
 
 class DataProviderTests extends AnyWordSpec with Matchers with BeforeAndAfterAll with Eventually {
-  private val mockHttp = new MockHttpServer
+    private val mockHttp = new MockHttpServer
 
-  private val config = ConfigFactory.empty()
-    .withValue("host", ConfigValueFactory.fromAnyRef("localhost"))
-    .withValue("port", ConfigValueFactory.fromAnyRef(Int.box(mockHttp.port)))
+    private val config = ConfigFactory.empty()
+        .withValue("host", ConfigValueFactory.fromAnyRef("localhost"))
+        .withValue("port", ConfigValueFactory.fromAnyRef(Int.box(mockHttp.port)))
 
-  private implicit val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
+    private implicit val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
 
-  override def beforeAll(): Unit = {
-    mockHttp.start()
-  }
-
-  override def afterAll(): Unit = mockHttp.stop()
-
-  "data can be scraped from EnvoyS on interval" when {
-    "only a single one is configured" in {
-      mockHttp.register("/ivp/meters")(Envoy.sampleMeter)
-      mockHttp.register("/ivp/meters/readings")(Envoy.sampleMeterReadings(activePower = 666.0, actEnergyDlvd = 777.0))
-
-      val provider = new EnvoyDataProvider(config)
-      provider.start(1.second)
-
-      eventually(timeout(Span(10, Seconds))) {
-        provider.currentProduction should be(666)
-        provider.totalProduction should be(777)
-      }
-
-      provider.stop()
-    }
-  }
-
-  "multiple ones are aggregated through an AccumulatingDataProvider" in {
-    mockHttp.register("/ivp/meters")(Envoy.sampleMeter)
-    mockHttp.register("/ivp/meters/readings")(Envoy.sampleMeterReadings(activePower = 111.0, actEnergyDlvd = 222.0))
-
-    val COUNT = 3
-    val providers = (0 until COUNT).map(_ => new EnvoyDataProvider(config))
-    val provider = new AccumulatingDataProvider(providers)
-    providers.foreach(_.start(1.second))
-
-    eventually(timeout(Span(10, Seconds))) {
-      provider.currentProduction should be(111 * COUNT)
-      provider.totalProduction should be(222 * COUNT)
+    override def beforeAll(): Unit = {
+        mockHttp.start()
     }
 
-    providers.foreach(_.stop())
-  }
+    override def afterAll(): Unit = mockHttp.stop()
+
+    "data can be scraped from EnvoyS on interval" when {
+        "only a single one is configured" in {
+            mockHttp.register("/ivp/meters")(Envoy.sampleMeter)
+            mockHttp.register("/ivp/meters/readings")(Envoy.sampleMeterReadings(activePower = 666.0, actEnergyDlvd = 777.0))
+
+            val provider = new EnvoyDataProvider(config)
+            provider.start(1.second)
+
+            eventually(timeout(Span(10, Seconds))) {
+                provider.currentProduction should be(666)
+                provider.totalProduction should be(777)
+            }
+
+            provider.stop()
+        }
+    }
+
+    "multiple ones are aggregated through an AccumulatingDataProvider" in {
+        mockHttp.register("/ivp/meters")(Envoy.sampleMeter)
+        mockHttp.register("/ivp/meters/readings")(Envoy.sampleMeterReadings(activePower = 111.0, actEnergyDlvd = 222.0))
+
+        val COUNT = 3
+        val providers = (0 until COUNT).map(_ => new EnvoyDataProvider(config))
+        val provider = new AccumulatingDataProvider(providers)
+        providers.foreach(_.start(1.second))
+
+        eventually(timeout(Span(10, Seconds))) {
+            provider.currentProduction should be(111 * COUNT)
+            provider.totalProduction should be(222 * COUNT)
+        }
+
+        providers.foreach(_.stop())
+    }
 }

--- a/src/test/scala/envoy/DataProviderWithAuthTests.scala
+++ b/src/test/scala/envoy/DataProviderWithAuthTests.scala
@@ -3,109 +3,110 @@ package envoy
 import cloutrix.energy.envoy.EnvoyDataProvider
 import cloutrix.energy.internal.AccumulatingDataProvider
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Seconds, Span}
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import testutils.MockHttpServer
 
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.{Executors, ScheduledExecutorService}
 import scala.concurrent.duration.DurationInt
 
 class DataProviderWithAuthTests extends AnyWordSpec with Matchers with BeforeAndAfterAll with BeforeAndAfter with Eventually {
-  private val mockHttp = new MockHttpServer
+    private val mockHttp = new MockHttpServer
 
-  private val config = ConfigFactory.empty()
-    .withValue("host", ConfigValueFactory.fromAnyRef("localhost"))
-    .withValue("port", ConfigValueFactory.fromAnyRef(Int.box(mockHttp.port)))
-    .withValue("login.url" , ConfigValueFactory.fromAnyRef(s"http://localhost:${mockHttp.port}/login"))
-    .withValue("token.url" , ConfigValueFactory.fromAnyRef(s"http://localhost:${mockHttp.port}/token"))
-    .withValue("username", ConfigValueFactory.fromAnyRef("dummy"))
-    .withValue("password", ConfigValueFactory.fromAnyRef("password.1"))
-    .withValue("serial", ConfigValueFactory.fromAnyRef("serial-number"))
+    private val config = ConfigFactory.empty()
+        .withValue("host", ConfigValueFactory.fromAnyRef("localhost"))
+        .withValue("port", ConfigValueFactory.fromAnyRef(Int.box(mockHttp.port)))
+        .withValue("login.url" , ConfigValueFactory.fromAnyRef(s"http://localhost:${mockHttp.port}/login"))
+        .withValue("token.url" , ConfigValueFactory.fromAnyRef(s"http://localhost:${mockHttp.port}/token"))
+        .withValue("username", ConfigValueFactory.fromAnyRef("dummy"))
+        .withValue("password", ConfigValueFactory.fromAnyRef("password.1"))
+        .withValue("serial", ConfigValueFactory.fromAnyRef("serial-number"))
 
-  private implicit val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
+    private implicit val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
 
-  private var loginDone: Boolean = false
-  private var tokenDone: Boolean = false
+    private val loginDone = new AtomicBoolean(false)
+    private val tokenDone = new AtomicBoolean(false)
 
-  override def beforeAll(): Unit = {
-    mockHttp.start()
-    mockHttp.register("/login") { loginDone = true ; """{"session_id": "deadbeaf","manager_token":"xxxxxxxxxx"}""" }
-    mockHttp.register("/token") { tokenDone = true ; "xxxxxxxxxx-xxx-xxx-xxxxxxxxxx" }
-  }
-
-  override def afterAll(): Unit = mockHttp.stop()
-
-  before {
-    loginDone = false
-    tokenDone = false
-  }
-
-  after { }
-
-  "data can be scraped from EnvoyS on interval" when {
-    "an intermediate 401 is returned" in {
-      mockHttp.register("/ivp/meters")(Envoy.sampleMeter)
-      mockHttp.register("/ivp/meters/readings")(Envoy.sampleMeterReadings(activePower = 666.0, actEnergyDlvd = 777.0))
-
-      val provider = new EnvoyDataProvider(config)
-      provider.start(1.second)
-
-      eventually(timeout(Span(10, Seconds))) {
-        loginDone should be(true)
-        tokenDone should be(true)
-        provider.currentProduction should be(666)
-        provider.totalProduction should be(777)
-      }
-
-      loginDone = false
-      tokenDone = false
-      mockHttp.force401()
-
-      eventually(timeout(Span(10, Seconds))) {
-        loginDone should be(true)
-        tokenDone should be(true)
-        provider.currentProduction should be(666)
-        provider.totalProduction should be(777)
-      }
+    override def beforeAll(): Unit = {
+        mockHttp.start()
+        mockHttp.register("/login") { loginDone.set(true) ; """{"session_id": "deadbeaf","manager_token":"xxxxxxxxxx"}""" }
+        mockHttp.register("/token") { tokenDone.set(true) ; "xxxxxxxxxx-xxx-xxx-xxxxxxxxxx" }
     }
 
-    "only a single one is configured" in {
-      mockHttp.register("/ivp/meters")(Envoy.sampleMeter)
-      mockHttp.register("/ivp/meters/readings")(Envoy.sampleMeterReadings(activePower = 666.0, actEnergyDlvd = 777.0))
+    override def afterAll(): Unit = mockHttp.stop()
 
-      val provider = new EnvoyDataProvider(config)
-      provider.start(1.second)
-
-      eventually(timeout(Span(10, Seconds))) {
-        loginDone should be(true)
-        tokenDone should be(true)
-        provider.currentProduction should be(666)
-        provider.totalProduction should be(777)
-      }
-
-      provider.stop()
-    }
-  }
-
-  "multiple ones are aggregated through an AccumulatingDataProvider" in {
-    mockHttp.register("/ivp/meters")(Envoy.sampleMeter)
-    mockHttp.register("/ivp/meters/readings")(Envoy.sampleMeterReadings(activePower = 111.0, actEnergyDlvd = 222.0))
-
-    val COUNT = 3
-    val providers = (0 until COUNT).map(_ => new EnvoyDataProvider(config))
-    val provider = new AccumulatingDataProvider(providers)
-    providers.foreach(_.start(1.second))
-
-    eventually(timeout(Span(10, Seconds))) {
-      loginDone should be(true)
-      tokenDone should be(true)
-      provider.currentProduction should be(111 * COUNT)
-      provider.totalProduction should be(222 * COUNT)
+    before {
+        loginDone.set(false)
+        tokenDone.set(false)
     }
 
-    providers.foreach(_.stop())
-  }
+    after { }
+
+    "data can be scraped from EnvoyS on interval" when {
+        "an intermediate 401 is returned" in {
+            mockHttp.register("/ivp/meters")(Envoy.sampleMeter)
+            mockHttp.register("/ivp/meters/readings")(Envoy.sampleMeterReadings(activePower = 666.0, actEnergyDlvd = 777.0))
+
+            val provider = new EnvoyDataProvider(config)
+            provider.start(1.second)
+
+            eventually(timeout(Span(10, Seconds))) {
+                loginDone.get() should be(true)
+                tokenDone.get() should be(true)
+                provider.currentProduction should be(666)
+                provider.totalProduction should be(777)
+            }
+
+            loginDone.set(false)
+            tokenDone.set(false)
+            mockHttp.force401()
+
+            eventually(timeout(Span(10, Seconds))) {
+                loginDone.get() should be(true)
+                tokenDone.get() should be(true)
+                provider.currentProduction should be(666)
+                provider.totalProduction should be(777)
+            }
+        }
+
+        "only a single one is configured" in {
+            mockHttp.register("/ivp/meters")(Envoy.sampleMeter)
+            mockHttp.register("/ivp/meters/readings")(Envoy.sampleMeterReadings(activePower = 666.0, actEnergyDlvd = 777.0))
+
+            val provider = new EnvoyDataProvider(config)
+            provider.start(1.second)
+
+            eventually(timeout(Span(10, Seconds))) {
+                loginDone.get() should be(true)
+                tokenDone.get() should be(true)
+                provider.currentProduction should be(666)
+                provider.totalProduction should be(777)
+            }
+
+            provider.stop()
+        }
+    }
+
+    "multiple ones are aggregated through an AccumulatingDataProvider" in {
+        mockHttp.register("/ivp/meters")(Envoy.sampleMeter)
+        mockHttp.register("/ivp/meters/readings")(Envoy.sampleMeterReadings(activePower = 111.0, actEnergyDlvd = 222.0))
+
+        val COUNT = 3
+        val providers = (0 until COUNT).map(_ => new EnvoyDataProvider(config))
+        val provider = new AccumulatingDataProvider(providers)
+        providers.foreach(_.start(1.second))
+
+        eventually(timeout(Span(10, Seconds))) {
+            loginDone.get() should be(true)
+            tokenDone.get() should be(true)
+            provider.currentProduction should be(111 * COUNT)
+            provider.totalProduction should be(222 * COUNT)
+        }
+
+        providers.foreach(_.stop())
+    }
 }

--- a/src/test/scala/envoy/EnphaseLoginTests.scala
+++ b/src/test/scala/envoy/EnphaseLoginTests.scala
@@ -1,0 +1,46 @@
+package envoy
+
+import cloutrix.energy.envoy.EnvoyDataProvider
+import com.typesafe.config.ConfigFactory
+import org.scalatest.concurrent.Eventually
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{BeforeAndAfterAll, Inside}
+
+import scala.util.{Success, Try}
+
+/**
+ * Requires following ENV vars to be set
+ *  - ENLIGHTEN_SERIAL
+ *  - ENLIGHTEN_USERNAME
+ *  - ENLIGHTEN_PASSWORD
+ *
+ * The tests will be ignored when these variables are not found.
+ */
+class EnphaseLoginTests  extends AnyWordSpec with Inside with Matchers with BeforeAndAfterAll with Eventually {
+    private val config = Try(ConfigFactory.load("test-envoy-login.conf").getConfig("EnvoyS.config"))
+
+    config.map(_.getString("username")) -> config.map(_.getString("password")) -> config.map(_.getString("serial")) match {
+        case Success(u) -> Success(p) -> Success(s) => doTests(u, p, s)
+        case _ =>
+            "can login to Enlighten API with real credentials" is pending
+            "can get JWT from login" is pending
+    }
+
+    def doTests(user: String, password: String, serial: String): Unit = {
+        "can login to Enlighten API with real credentials" in {
+            inside(EnvoyDataProvider.onManagementSession(user, password)(config.get)) {
+                case Success(r) =>
+                    println(r)
+            }
+        }
+
+        "can get JWT from login" in {
+            val sessionId = EnvoyDataProvider.onManagementSession(user, password)(config.get).get
+            inside(EnvoyDataProvider.fetchJwt(sessionId, serial, user)(config.get)) {
+                case Success(r) =>
+                    println(r)
+            }
+        }
+    }
+}

--- a/src/test/scala/modbus/PipelineTest.scala
+++ b/src/test/scala/modbus/PipelineTest.scala
@@ -16,85 +16,85 @@ import testutils.Profiling
 import scala.concurrent.duration.DurationInt
 
 class PipelineTest extends AnyWordSpec with Matchers with Inside with Eventually with Profiling {
-  ResourceLeakDetector.setLevel(Level.PARANOID)
+    ResourceLeakDetector.setLevel(Level.PARANOID)
 
-  private val mapper = new SunspecDataMapper(Map(
-    30529 -> (() => 666),
-    30775 -> (() => 777)
-  ))
+    private val mapper = new SunspecDataMapper(Map(
+        30529 -> (() => 666),
+        30775 -> (() => 777)
+    ))
 
-  private def withChannel[T](f: EmbeddedChannel => T) = {
-    val ch = new EmbeddedChannel()
-    new ModbusChannelInitializer(mapper).initChannel(ch) // full pipeline
-    ch.pipeline().fireChannelActive() // trigger activation
+    private def withChannel[T](f: EmbeddedChannel => T) = {
+        val ch = new EmbeddedChannel()
+        new ModbusChannelInitializer(mapper).initChannel(ch) // full pipeline
+        ch.pipeline().fireChannelActive() // trigger activation
 
-    f(ch)
-    ch.finishAndReleaseAll()
-  }
+        f(ch)
+        ch.finishAndReleaseAll()
+    }
 
-  "full pipeline" should {
-    "close the channel" when {
-      "an unsupported Modbus function is requested" in {
-        val raw30666 = Seq(0x41, 0xf7, 0x00, 0x00, 0x00, 0x06, 0x03, 0x03, 0x77, 0xCA, 0x00, 0x02).map(_.toByte).toArray
+    "full pipeline" should {
+        "close the channel" when {
+            "an unsupported Modbus function is requested" in {
+                val raw30666 = Seq(0x41, 0xf7, 0x00, 0x00, 0x00, 0x06, 0x03, 0x03, 0x77, 0xCA, 0x00, 0x02).map(_.toByte).toArray
 
-        withChannel { ch =>
-          ch.writeInbound(Unpooled.wrappedBuffer(raw30666))
-          eventually(timeout(Span(5, Seconds)))(ch.isActive should be (false))   // channel closed by service
-        }
-      }
-
-      "nothing got received on the channel for 10 seconds" in {
-        withChannel { ch =>
-          val d = Time {
-            eventually(timeout(Span(15, Seconds)), interval(Span(100, Milliseconds))) {
-              ch.runPendingTasks()
-              ch.isActive should be(false)
+                withChannel { ch =>
+                    ch.writeInbound(Unpooled.wrappedBuffer(raw30666))
+                    eventually(timeout(Span(5, Seconds)))(ch.isActive should be (false))   // channel closed by service
+                }
             }
-          }
 
-          d.toMillis should (be > 10.seconds.toMillis)
+            "nothing got received on the channel for 10 seconds" in {
+                withChannel { ch =>
+                    val d = Time {
+                        eventually(timeout(Span(15, Seconds)), interval(Span(100, Milliseconds))) {
+                            ch.runPendingTasks()
+                            ch.isActive should be(false)
+                        }
+                    }
+
+                    d.toMillis should (be > 10.seconds.toMillis)
+                }
+            }
         }
-      }
-    }
 
-    "be able to handle chunked input" in {
-      val raw30529_1 = Seq(0x41, 0xf7, 0x00, 0x00, 0x00, 0x06, 0x03).map(_.toByte).toArray
-      val raw30529_2 = Seq(0x03, 0x77, 0x41, 0x00, 0x02).map(_.toByte).toArray
+        "be able to handle chunked input" in {
+            val raw30529_1 = Seq(0x41, 0xf7, 0x00, 0x00, 0x00, 0x06, 0x03).map(_.toByte).toArray
+            val raw30529_2 = Seq(0x03, 0x77, 0x41, 0x00, 0x02).map(_.toByte).toArray
 
-      withChannel { ch =>
-        ch.writeInbound(Unpooled.wrappedBuffer(raw30529_1))
-        ch.writeInbound(Unpooled.wrappedBuffer(raw30529_2))
-        inside(ch.outboundMessages().poll()) {
-          case buf: ByteBuf =>
-            ch.isActive should be(true)
-            ByteBufUtil.getBytes(buf).toSeq should contain theSameElementsInOrderAs Seq(
-              0x41, 0xf7, 0x00, 0x00, 0x00, 0x07, 0x03, 0x03, 0x04, 0x00, 0x00, 0x02, 0x9a).map(_.toByte)
+            withChannel { ch =>
+                ch.writeInbound(Unpooled.wrappedBuffer(raw30529_1))
+                ch.writeInbound(Unpooled.wrappedBuffer(raw30529_2))
+                inside(ch.outboundMessages().poll()) {
+                    case buf: ByteBuf =>
+                        ch.isActive should be(true)
+                        ByteBufUtil.getBytes(buf).toSeq should contain theSameElementsInOrderAs Seq(
+                            0x41, 0xf7, 0x00, 0x00, 0x00, 0x07, 0x03, 0x03, 0x04, 0x00, 0x00, 0x02, 0x9a).map(_.toByte)
 
-            buf.release()
+                        buf.release()
+                }
+            }
         }
-      }
-    }
 
-    "not introduce memory leaks" in {
-      val raw30529 = Seq(0x41, 0xf7, 0x00, 0x00, 0x00, 0x06, 0x03, 0x03, 0x77, 0x41, 0x00, 0x02).map(_.toByte).toArray
-      val raw30775 = Seq(0x1d, 0x7b, 0x00, 0x00, 0x00, 0x06, 0x03, 0x03, 0x78, 0x37, 0x00, 0x02).map(_.toByte).toArray
+        "not introduce memory leaks" in {
+            val raw30529 = Seq(0x41, 0xf7, 0x00, 0x00, 0x00, 0x06, 0x03, 0x03, 0x77, 0x41, 0x00, 0x02).map(_.toByte).toArray
+            val raw30775 = Seq(0x1d, 0x7b, 0x00, 0x00, 0x00, 0x06, 0x03, 0x03, 0x78, 0x37, 0x00, 0x02).map(_.toByte).toArray
 
-      def test(ar: Array[Byte], expected: Seq[Byte]) = withChannel { ch =>
-        ch.writeInbound(Unpooled.wrappedBuffer(ar))
-        inside(ch.outboundMessages().poll()) {
-          case buf: ByteBuf =>
-            ch.isActive should be (true)
-            ByteBufUtil.getBytes(buf).toSeq should contain theSameElementsInOrderAs expected
-            buf.release()
+            def test(ar: Array[Byte], expected: Seq[Byte]) = withChannel { ch =>
+                ch.writeInbound(Unpooled.wrappedBuffer(ar))
+                inside(ch.outboundMessages().poll()) {
+                    case buf: ByteBuf =>
+                        ch.isActive should be (true)
+                        ByteBufUtil.getBytes(buf).toSeq should contain theSameElementsInOrderAs expected
+                        buf.release()
+                }
+            }
+
+            Loop(10.seconds, 10.milliseconds) {
+                test(raw30529, Seq(0x41, 0xf7, 0x00, 0x00, 0x00, 0x07, 0x03, 0x03, 0x04, 0x00, 0x00, 0x02, 0x9a).map(_.toByte))
+                test(raw30775, Seq(0x1d, 0x7b, 0x00, 0x00, 0x00, 0x07, 0x03, 0x03, 0x04, 0x00, 0x00, 0x03, 0x09).map(_.toByte))
+            }
+
+            System.gc()
         }
-      }
-
-      Loop(10.seconds, 10.milliseconds) {
-        test(raw30529, Seq(0x41, 0xf7, 0x00, 0x00, 0x00, 0x07, 0x03, 0x03, 0x04, 0x00, 0x00, 0x02, 0x9a).map(_.toByte))
-        test(raw30775, Seq(0x1d, 0x7b, 0x00, 0x00, 0x00, 0x07, 0x03, 0x03, 0x04, 0x00, 0x00, 0x03, 0x09).map(_.toByte))
-      }
-
-      System.gc()
     }
-  }
 }

--- a/src/test/scala/saj/DataProviderTests.scala
+++ b/src/test/scala/saj/DataProviderTests.scala
@@ -14,49 +14,49 @@ import java.util.concurrent.{Executors, ScheduledExecutorService}
 import scala.concurrent.duration.DurationInt
 
 class DataProviderTests extends AnyWordSpec with Matchers with BeforeAndAfterAll with Eventually {
-  private val mockHttp = new MockHttpServer
+    private val mockHttp = new MockHttpServer
 
-  private val config = ConfigFactory.empty()
-    .withValue("host", ConfigValueFactory.fromAnyRef("localhost"))
-    .withValue("port", ConfigValueFactory.fromAnyRef(Int.box(mockHttp.port)))
+    private val config = ConfigFactory.empty()
+        .withValue("host", ConfigValueFactory.fromAnyRef("localhost"))
+        .withValue("port", ConfigValueFactory.fromAnyRef(Int.box(mockHttp.port)))
 
-  private implicit val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
+    private implicit val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
 
-  override def beforeAll(): Unit = {
-    mockHttp.start()
-  }
-
-  override def afterAll(): Unit = mockHttp.stop()
-
-  "data can be scraped from SAJ on interval" when {
-    "only a single one is configured" in {
-      mockHttp.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = 666.0, actEnergyDlvd = 0.777 /*kWh*/))
-
-      val provider = new SajDataProvider(config)
-      provider.start(1.second)
-
-      eventually(timeout(Span(10, Seconds))) {
-        provider.currentProduction should be(666)
-        provider.totalProduction should be(777)  /*Wh*/
-      }
-
-      provider.stop()
-    }
-  }
-
-  "multiple ones are aggregated through an AccumulatingDataProvider" in {
-    mockHttp.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = 111.0, actEnergyDlvd = 0.222 /*kWh*/))
-
-    val COUNT = 3
-    val providers = (0 until COUNT).map(_ => new SajDataProvider(config))
-    val provider = new AccumulatingDataProvider(providers)
-    providers.foreach(_.start(1.second))
-
-    eventually(timeout(Span(10, Seconds))) {
-      provider.currentProduction should be(111 * COUNT)
-      provider.totalProduction should be(222 * COUNT) /*Wh*/
+    override def beforeAll(): Unit = {
+        mockHttp.start()
     }
 
-    providers.foreach(_.stop())
-  }
+    override def afterAll(): Unit = mockHttp.stop()
+
+    "data can be scraped from SAJ on interval" when {
+        "only a single one is configured" in {
+            mockHttp.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = 666.0, actEnergyDlvd = 0.777 /*kWh*/))
+
+            val provider = new SajDataProvider(config)
+            provider.start(1.second)
+
+            eventually(timeout(Span(10, Seconds))) {
+                provider.currentProduction should be(666)
+                provider.totalProduction should be(777)  /*Wh*/
+            }
+
+            provider.stop()
+        }
+    }
+
+    "multiple ones are aggregated through an AccumulatingDataProvider" in {
+        mockHttp.register("/real_time_data.xml")(SAJ.sampleMeterReadings(activePower = 111.0, actEnergyDlvd = 0.222 /*kWh*/))
+
+        val COUNT = 3
+        val providers = (0 until COUNT).map(_ => new SajDataProvider(config))
+        val provider = new AccumulatingDataProvider(providers)
+        providers.foreach(_.start(1.second))
+
+        eventually(timeout(Span(10, Seconds))) {
+            provider.currentProduction should be(111 * COUNT)
+            provider.totalProduction should be(222 * COUNT) /*Wh*/
+        }
+
+        providers.foreach(_.stop())
+    }
 }

--- a/src/test/scala/testutils/ByteConversions.scala
+++ b/src/test/scala/testutils/ByteConversions.scala
@@ -3,5 +3,5 @@ package testutils
 import java.nio.ByteBuffer
 
 trait ByteConversions {
-  def LastInt(a: => Array[Byte]): Int = ByteBuffer.wrap(a.takeRight(4)).getInt
+    def LastInt(a: => Array[Byte]): Int = ByteBuffer.wrap(a.takeRight(4)).getInt
 }

--- a/src/test/scala/testutils/MockHttpServer.scala
+++ b/src/test/scala/testutils/MockHttpServer.scala
@@ -1,41 +1,38 @@
 package testutils
 
 import com.sun.net.httpserver.{HttpExchange, HttpServer}
+import com.typesafe.scalalogging.StrictLogging
 import org.scalatest.Assertions.fail
 
 import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.util.Using
 
-class MockHttpServer extends TestSockets {
-  private val server = HttpServer.create(new InetSocketAddress("localhost", anyFreePort), 0)
+class MockHttpServer extends TestSockets with StrictLogging {
+    private val server = HttpServer.create(new InetSocketAddress("localhost", anyFreePort), 0)
+    private val respond401 = new AtomicBoolean(false)
+    private var handlers = Map.empty[String, () => String]
 
-  def port: Int = server.getAddress.getPort
+    def port: Int = server.getAddress.getPort
+    def start(): Unit = server.start()
+    def stop(): Unit = server.stop(0)
+    def force401(): Unit = respond401.set(true)
 
-  def start(): Unit = server.start()
-  def stop(): Unit = server.stop(0)
+    server.createContext("/", (_: HttpExchange) match {
+        case http if respond401.get() =>
+            respond401.set(false)
+            http.sendResponseHeaders(401, -1)
 
-  private var respond401 = false
+        case http =>
+            handlers.get(http.getRequestURI.getPath)
+                .map(_())
+                .tapEach(body => http.sendResponseHeaders(200, body.length))
+                .map { body =>
+                    Using.resource(http.getResponseBody) { os => os.write(body.getBytes) ; os.flush() }
+                }
+                .headOption
+                .getOrElse { fail() }: Unit
+    })
 
-  def force401(): Unit = respond401 = true
-
-  private var handlers = Map.empty[String, () => String]
-
-  server.createContext("/", (http: HttpExchange) => {
-    if(respond401) {
-      respond401 = false
-      http.sendResponseHeaders(401, -1)
-    }
-    else {
-      handlers.get(http.getRequestURI.getPath)
-        .map(_())
-        .tapEach(body => http.sendResponseHeaders(200, body.length))
-        .map { body =>
-          Using.resource(http.getResponseBody) { os => os.write(body.getBytes) ; os.flush() }
-        }
-        .headOption
-        .getOrElse { fail() }: Unit
-    }
-  })
-
-  def register(path: String)(handler: => String): Unit = handlers += (path -> { () => handler })
+    def register(path: String)(handler: => String): Unit = handlers += (path -> { () => handler })
 }

--- a/src/test/scala/testutils/Profiling.scala
+++ b/src/test/scala/testutils/Profiling.scala
@@ -6,25 +6,23 @@ import scala.language.postfixOps
 import scala.util.chaining.scalaUtilChainingOps
 
 trait Profiling {
-  def Loop[T](duration: FiniteDuration, interval: Duration = Duration.Zero)(block: => T): Long = {
-    val start = System.currentTimeMillis()
+    def Loop[T](duration: FiniteDuration, interval: Duration = Duration.Zero)(block: => T): (Long, T) = {
+        val start = System.currentTimeMillis()
 
-    @tailrec def run(count: Long = 0L): Long = {
-      if(System.currentTimeMillis() - start >= duration.toMillis) return count
+        @tailrec def run(count: Long = 1L, result: T): (Long, T) = {
+            if(System.currentTimeMillis() - start >= duration.toMillis) return (count, result)
+            if(interval.gt(Duration.Zero)) Thread.sleep(interval.toMillis)
+            run(count + 1, block)
+        }
 
-      val rT = block
-      if(interval.gt(Duration.Zero)) Thread.sleep(interval.toMillis)
-      run(count + 1)
+        run(result = block)
     }
 
-    run()
-  }
-
-  def Time[T](block: => T): FiniteDuration = {
-    Some(System.nanoTime())
-      .tap(_ => block)
-      .map(System.nanoTime() - _)
-      .map(Duration.fromNanos)
-      .get
-  }
+    def Time[T](block: => T): FiniteDuration = {
+        Some(System.nanoTime())
+            .tap(_ => block)
+            .map(System.nanoTime() - _)
+            .map(Duration.fromNanos)
+            .get
+    }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.0.5-SNAPSHOT"
+ThisBuild / version := "1.1.0-SNAPSHOT"


### PR DESCRIPTION
Apparently Enphase does not support `Content-Type: application/x-www-form-urlencoded` but instead expects `Content-Type: multipart/form-data` when logging in into the API to get a JWT token.